### PR TITLE
feat(lyrics): animate size and fade of active line

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Lyrics.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Lyrics.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.annotation.RequiresApi
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -632,6 +633,25 @@ fun Lyrics(
                     key = { index, item -> "$index-${item.time}" } // Add stable key
                 ) { index, item ->
                     val isSelected = selectedIndices.contains(index)
+
+                    val fontSize by animateFloatAsState(
+                        targetValue = if (index == displayedCurrentLineIndex && isSynced) 28f else 24f,
+                        animationSpec = tween(durationMillis = 1500),
+                        label = "font-size"
+                    )
+
+                    val alpha by animateFloatAsState(
+                        targetValue = when {
+                            !isSynced || (isSelectionModeActive && isSelected) -> 1f
+                            index == displayedCurrentLineIndex -> 1f
+                            kotlin.math.abs(index - displayedCurrentLineIndex) == 1 -> 0.7f
+                            kotlin.math.abs(index - displayedCurrentLineIndex) == 2 -> 0.4f
+                            else -> 0.2f
+                        },
+                        animationSpec = tween(durationMillis = 1500),
+                        label = "alpha"
+                    )
+
                     val itemModifier = Modifier
                         .fillMaxWidth()
                         .clip(RoundedCornerShape(8.dp)) // Clip for background
@@ -704,15 +724,7 @@ fun Lyrics(
                         )
                         .padding(horizontal = 24.dp, vertical = 8.dp)
                         // Metrolist-style depth effect with professional alpha transitions
-                        .alpha(
-                            when {
-                                !isSynced || (isSelectionModeActive && isSelected) -> 1f
-                                index == displayedCurrentLineIndex -> 1f // Active line - full opacity
-                                kotlin.math.abs(index - displayedCurrentLineIndex) == 1 -> 0.7f // Adjacent lines - medium opacity
-                                kotlin.math.abs(index - displayedCurrentLineIndex) == 2 -> 0.4f // 2 lines away - low opacity  
-                                else -> 0.2f // Far lines - very low opacity (deep water effect)
-                            }
-                        )
+                        .alpha(alpha)
                         // Add subtle scale effect for depth
                         .graphicsLayer {
                             val distance = kotlin.math.abs(index - displayedCurrentLineIndex)
@@ -736,7 +748,7 @@ fun Lyrics(
                     ) {
                         Text(
                             text = item.text,
-                            fontSize = 24.sp, // Uniform size for all lines matching latest enh version
+                            fontSize = fontSize.sp,
                             color = if (index == displayedCurrentLineIndex && isSynced) {
                                 textColor // Full color for active line
                             } else {


### PR DESCRIPTION
Adds a smooth animation to the lyrics screen. The active lyric line now animates its font size and alpha, creating a more visually appealing and polished user experience. This addresses the abrupt change in size and appearance of the active lyric line.

The animation is implemented using `animateFloatAsState` for both the font size and alpha, ensuring a smooth transition.