### PR TITLE
feat(lyrics): add bounce animation to active line

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Lyrics.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Lyrics.kt
@@ -7,7 +7,9 @@ import android.os.Build
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.annotation.RequiresApi
+import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -636,7 +638,10 @@ fun Lyrics(
 
                     val fontSize by animateFloatAsState(
                         targetValue = if (index == displayedCurrentLineIndex && isSynced) 28f else 24f,
-                        animationSpec = tween(durationMillis = 300),
+                        animationSpec = spring(
+                            dampingRatio = Spring.DampingRatioMediumBouncy,
+                            stiffness = Spring.StiffnessLow
+                        ),
                         label = "font-size"
                     )
 
@@ -648,7 +653,10 @@ fun Lyrics(
                             kotlin.math.abs(index - displayedCurrentLineIndex) == 2 -> 0.4f
                             else -> 0.2f
                         },
-                        animationSpec = tween(durationMillis = 300),
+                        animationSpec = spring(
+                            dampingRatio = Spring.DampingRatioMediumBouncy,
+                            stiffness = Spring.StiffnessLow
+                        ),
                         label = "alpha"
                     )
 


### PR DESCRIPTION
Adds a bounce animation to the active lyric line on the lyrics screen. The active lyric line now animates its font size and alpha with a spring animation, creating a more visually appealing and polished user experience. This addresses the abrupt change in size and appearance of the active lyric line.

The animation is implemented using `animateFloatAsState` with a `spring` spec for both the font size and alpha, ensuring a smooth, bouncy transition.