### PR TITLE
Fix: Offline Thumbnails Not Showing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ core
 core.*
 *.so
 *.bin
+app/persistent-debug.keystore

--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -12,6 +12,7 @@ import androidx.media3.common.MediaMetadata
 import androidx.media3.exoplayer.offline.Download
 import androidx.media3.session.LibraryResult
 import androidx.media3.session.MediaLibraryService
+import coil3.imageLoader
 import androidx.media3.session.MediaLibraryService.MediaLibrarySession
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSession.MediaItemsWithStartPosition
@@ -607,8 +608,17 @@ constructor(
                 .build(),
         ).build()
 
-    private fun Song.toMediaItem(path: String, isPlayable: Boolean = true, isBrowsable: Boolean = false) =
-        MediaItem
+    private fun Song.toMediaItem(path: String, isPlayable: Boolean = true, isBrowsable: Boolean = false): MediaItem {
+        val artworkUri = song.thumbnailUrl?.let {
+            val snapshot = context.imageLoader.diskCache?.openSnapshot(it)
+            if (snapshot != null) {
+                snapshot.use { snapshot -> snapshot.data.toFile().toUri() }
+            } else {
+                it.toUri()
+            }
+        }
+
+        return MediaItem
             .Builder()
             .setMediaId("$path/$id")
             .setMediaMetadata(
@@ -617,10 +627,11 @@ constructor(
                     .setTitle(song.title)
                     .setSubtitle(artists.joinToString { it.name })
                     .setArtist(artists.joinToString { it.name })
-                    .setArtworkUri(song.thumbnailUrl?.toUri())
+                    .setArtworkUri(artworkUri)
                     .setIsPlayable(isPlayable)
                     .setIsBrowsable(isBrowsable)
                     .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
                     .build(),
             ).build()
+    }
 }


### PR DESCRIPTION
This commit fixes a bug where song thumbnails would not display in widgets and other system UI components when the device was offline. This was happening for both downloaded and cached songs.

The `Song.toMediaItem` extension function in `MediaLibrarySessionCallback.kt` was modified to always check for a locally cached thumbnail image using the Coil `DiskCache`. If a cached image is found, a local file URI is used for the artwork. Otherwise, it falls back to the remote `thumbnailUrl`.

Additionally, the `persistent-debug.keystore` file was removed from the git index and added to the `.gitignore` file to prevent it from being committed to the repository.