### PR TITLE
feat: Fixes pure black mini-player toggle and refactors more menu button

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
@@ -87,6 +87,10 @@ import kotlinx.coroutines.launch
 import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
+import com.metrolist.music.constants.DarkModeKey
+import com.metrolist.music.ui.screens.settings.DarkMode
+import com.metrolist.music.utils.rememberEnumPreference
 
 @Composable
 fun MiniPlayer(
@@ -133,6 +137,11 @@ private fun NewMiniPlayer(
     val (pureBlack, onPureBlackChange) = rememberPreference(PureBlackMiniPlayerKey, defaultValue = false)
     val playerConnection = LocalPlayerConnection.current ?: return
     val database = LocalDatabase.current
+    val isSystemInDarkTheme = isSystemInDarkTheme()
+    val darkTheme by rememberEnumPreference(DarkModeKey, defaultValue = DarkMode.AUTO)
+    val useDarkTheme = remember(darkTheme, isSystemInDarkTheme) {
+        if (darkTheme == DarkMode.AUTO) isSystemInDarkTheme else darkTheme == DarkMode.ON
+    }
     val isPlaying by playerConnection.isPlaying.collectAsState()
     val playbackState by playerConnection.playbackState.collectAsState()
     val error by playerConnection.error.collectAsState()
@@ -272,7 +281,7 @@ private fun NewMiniPlayer(
                 .offset { IntOffset(offsetXAnimatable.value.roundToInt(), 0) }
                 .clip(RoundedCornerShape(32.dp)) // Clip first for perfect rounded corners
                 .background(
-                    color = if (pureBlack) Color.Black else MaterialTheme.colorScheme.surfaceContainer
+                    color = if (pureBlack && useDarkTheme) Color.Black else MaterialTheme.colorScheme.surfaceContainer
                 )
                 .border(
                     width = if (miniPlayerOutline) 1.dp else 0.dp,

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -742,37 +742,13 @@ fun BottomSheetPlayer(
 
                     Spacer(modifier = Modifier.size(12.dp))
 
-                    Box(
-                        contentAlignment = Alignment.Center,
-                        modifier =
-                        Modifier
-                            .size(40.dp)
-                            .clip(RoundedCornerShape(24.dp))
-                            .background(textButtonColor)
-                            .clickable {
-                                menuState.show {
-                                    PlayerMenu(
-                                        mediaMetadata = mediaMetadata,
-                                        navController = navController,
-                                        playerBottomSheetState = state,
-                                        onShowDetailsDialog = {
-                                            mediaMetadata.id.let {
-                                                bottomSheetPageState.show {
-                                                    ShowMediaInfo(it)
-                                                }
-                                            }
-                                        },
-                                        onDismiss = menuState::dismiss,
-                                    )
-                                }
-                            },
-                    ) {
-                        Image(
-                            painter = painterResource(R.drawable.more_horiz),
-                            contentDescription = null,
-                            colorFilter = ColorFilter.tint(iconButtonColor),
-                        )
-                    }
+                    PlayerMoreMenuButton(
+                        mediaMetadata = mediaMetadata,
+                        navController = navController,
+                        state = state,
+                        textButtonColor = textButtonColor,
+                        iconButtonColor = iconButtonColor,
+                    )
                 }
             }
 
@@ -1209,5 +1185,49 @@ private fun Modifier.bouncy(interactionSource: InteractionSource) = composed {
     graphicsLayer {
         scaleX = scale
         scaleY = scale
+    }
+}
+
+@Composable
+private fun PlayerMoreMenuButton(
+    mediaMetadata: MediaMetadata,
+    navController: NavController,
+    state: BottomSheetState,
+    textButtonColor: Color,
+    iconButtonColor: Color,
+) {
+    val menuState = LocalMenuState.current
+    val bottomSheetPageState = LocalBottomSheetPageState.current
+
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier =
+        Modifier
+            .size(40.dp)
+            .clip(RoundedCornerShape(24.dp))
+            .background(textButtonColor)
+            .clickable {
+                menuState.show {
+                    PlayerMenu(
+                        mediaMetadata = mediaMetadata,
+                        navController = navController,
+                        playerBottomSheetState = state,
+                        onShowDetailsDialog = {
+                            mediaMetadata.id.let {
+                                bottomSheetPageState.show {
+                                    ShowMediaInfo(it)
+                                }
+                            }
+                        },
+                        onDismiss = menuState::dismiss,
+                    )
+                }
+            },
+    ) {
+        Image(
+            painter = painterResource(R.drawable.more_horiz),
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(iconButtonColor),
+        )
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AppearanceSettings.kt
@@ -573,7 +573,7 @@ fun AppearanceSettings(
             }
         )
 
-        AnimatedVisibility(useNewMiniPlayerDesign) {
+        AnimatedVisibility(useNewMiniPlayerDesign && useDarkTheme) {
             val (pureBlackMiniPlayer, onPureBlackMiniPlayerChange) = rememberPreference(
                 PureBlackMiniPlayerKey,
                 defaultValue = false


### PR DESCRIPTION
This commit addresses two separate user requests:

1.  **Fixes the "Pure black mini-player" toggle.** The toggle was incorrectly applying a pure black background in light mode. This has been fixed by making the background conditional on both the setting being enabled and the dark theme being active. Additionally, the toggle is now only visible in the settings when dark mode is enabled.

2.  **Refactors the "more" menu button for clarity.** The "more" menu button on the player screen has been extracted into its own private composable function, `PlayerMoreMenuButton`. This improves code readability and makes the button's implementation easier to locate, without changing its appearance or functionality.