### PR TITLE
Fix: Overhaul Lyrics Fetching for Reliability

### DIFF
--- a/applelyrics/src/main/kotlin/com/mostafaalagamy/metrolist/applelyrics/AppleMusic.kt
+++ b/applelyrics/src/main/kotlin/com/mostafaalagamy/metrolist/applelyrics/AppleMusic.kt
@@ -62,7 +62,7 @@ object AppleMusic {
         return null
     }
 
-    suspend fun searchSong(songName: String, artistName: String): com.mostafaalagamy.metrolist.applelyrics.models.Track? {
+    suspend fun searchSong(songName: String, artistName: String): List<com.mostafaalagamy.metrolist.applelyrics.models.Track>? {
         val searchResponse = makeRequest("searchAppleMusic.php") { client, urlBuilder ->
             urlBuilder.parameters.append("q", "$songName $artistName")
             client.get(urlBuilder.build()).body<SearchResponse>()
@@ -72,41 +72,7 @@ object AppleMusic {
             return null
         }
 
-        var bestMatch: com.mostafaalagamy.metrolist.applelyrics.models.Track? = null
-        var maxScore = -1
-
-        for (track in searchResponse) {
-            var currentScore = 0
-
-            // Score based on title match
-            val titleMatchScore = when {
-                track.songName.equals(songName, ignoreCase = true) -> 100
-                songName.contains(track.songName, ignoreCase = true) -> 50 + track.songName.length
-                track.songName.contains(songName, ignoreCase = true) -> 50 + songName.length
-                else -> -1 // Not a match
-            }
-
-            if (titleMatchScore == -1) {
-                continue
-            }
-            currentScore += titleMatchScore
-
-            // Score based on artist match
-            val artistMatchScore = when {
-                track.artistName.equals(artistName, ignoreCase = true) -> 50
-                artistName.contains(track.artistName, ignoreCase = true) -> 25
-                track.artistName.contains(artistName, ignoreCase = true) -> 25
-                else -> 0
-            }
-            currentScore += artistMatchScore
-
-            if (currentScore > maxScore) {
-                maxScore = currentScore
-                bestMatch = track
-            }
-        }
-
-        return bestMatch
+        return searchResponse
     }
 
     suspend fun getLyrics(id: String): String? {


### PR DESCRIPTION
This commit provides a comprehensive overhaul of the lyrics fetching system to address multiple critical bugs, including a race condition that caused the user's preferred provider to be ignored.

Key changes:
- **State-Aware Refactor:** `LyricsHelper` has been refactored to be stateless. It now fetches the user's preferred provider from `DataStore` on every `getLyrics` call, completely eliminating the race condition that occurred during app startup.
- **Corrected Fallback Logic:** Fixed a critical bug where the `coroutineScope` was preventing lyrics from fallback providers from being returned correctly.
- **Improved Apple Music Matching:** Implemented a "smart match" scoring algorithm in the `AppleMusicLyricsProvider`. The provider now fetches a list of results, scores them based on title and artist similarity, and then attempts to get lyrics for the best match, significantly improving accuracy.
- **Increased Timeout:** The preferred provider timeout has been increased to 15 seconds to better handle slower network requests.