### PR TITLE
Add repo.md with upstream information

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -1,0 +1,1 @@
+# Metrolist Repository\n\nUpstream: https://github.com/mostafaalagamy/Metrolist


### PR DESCRIPTION
Created .openhands/microagents/repo.md file with the upstream repository information as requested.

The file contains:
- Upstream: https://github.com/mostafaalagamy/Metrolist

This change helps document the repository's upstream source for future reference.

@adrielGGmotion can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d86759aaf5ba45f2b79daba344fa8221)