### PR TITLE
Feat: Add Material You 3 Custom Color Picker

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -127,6 +127,7 @@ import com.metrolist.music.constants.CheckForUpdatesKey
 import com.metrolist.music.constants.DarkModeKey
 import com.metrolist.music.constants.DefaultOpenTabKey
 import com.metrolist.music.constants.DisableScreenshotKey
+import com.metrolist.music.constants.CustomThemeColorKey
 import com.metrolist.music.constants.DynamicThemeKey
 import com.metrolist.music.constants.MiniPlayerBottomSpacing
 import com.metrolist.music.constants.MiniPlayerHeight
@@ -372,6 +373,7 @@ class MainActivity : ComponentActivity() {
         }
 
         val enableDynamicTheme by rememberPreference(DynamicThemeKey, defaultValue = true)
+        val customThemeColor by rememberPreference(CustomThemeColorKey, defaultValue = DefaultThemeColor.toArgb())
         val darkTheme by rememberEnumPreference(DarkModeKey, defaultValue = DarkMode.AUTO)
         val isSystemInDarkTheme = isSystemInDarkTheme()
         val useDarkTheme = remember(darkTheme, isSystemInDarkTheme) {
@@ -391,10 +393,10 @@ class MainActivity : ComponentActivity() {
             mutableStateOf(DefaultThemeColor)
         }
 
-        LaunchedEffect(playerConnection, enableDynamicTheme) {
+        LaunchedEffect(playerConnection, enableDynamicTheme, customThemeColor) {
             val playerConnection = playerConnection
             if (!enableDynamicTheme || playerConnection == null) {
-                themeColor = DefaultThemeColor
+                themeColor = Color(customThemeColor)
                 return@LaunchedEffect
             }
 
@@ -412,14 +414,14 @@ class MainActivity : ComponentActivity() {
                                     .crossfade(false)
                                     .build()
                             )
-                            themeColor = result.image?.toBitmap()?.extractThemeColor() ?: DefaultThemeColor
+                            themeColor = result.image?.toBitmap()?.extractThemeColor() ?: Color(customThemeColor)
                         } catch (e: Exception) {
                             // Fallback to default on error
-                            themeColor = DefaultThemeColor
+                            themeColor = Color(customThemeColor)
                         }
                     }
                 } else {
-                    themeColor = DefaultThemeColor
+                    themeColor = Color(customThemeColor)
                 }
             }
         }

--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -15,6 +15,7 @@ import java.time.ZoneOffset
 
 val EnableDynamicIconKey = booleanPreferencesKey("enableDynamicIcon")
 val DynamicThemeKey = booleanPreferencesKey("dynamicTheme")
+val CustomThemeColorKey = intPreferencesKey("customThemeColor")
 val DarkModeKey = stringPreferencesKey("darkMode")
 val PureBlackKey = booleanPreferencesKey("pureBlack")
 val PureBlackMiniPlayerKey = booleanPreferencesKey("pureBlackMiniPlayer")

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/ColorPickerDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/ColorPickerDialog.kt
@@ -1,0 +1,172 @@
+package com.metrolist.music.ui.component
+
+import android.graphics.Color as AndroidColor
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import com.metrolist.music.R
+import kotlin.math.roundToInt
+
+@Composable
+fun ColorPickerDialog(
+    initialColor: Color,
+    onDismiss: () -> Unit,
+    onColorSelected: (Color) -> Unit
+) {
+    var hue by remember { mutableFloatStateOf(0f) }
+    var saturation by remember { mutableFloatStateOf(1f) }
+    var value by remember { mutableFloatStateOf(1f) }
+
+    LaunchedEffect(initialColor) {
+        val hsv = FloatArray(3)
+        AndroidColor.colorToHSV(initialColor.toArgb(), hsv)
+        hue = hsv[0]
+        saturation = hsv[1]
+        value = hsv[2]
+    }
+
+    val currentColor = remember(hue, saturation, value) {
+        Color(AndroidColor.HSVToColor(floatArrayOf(hue, saturation, value)))
+    }
+
+    val presets = remember {
+        listOf(
+            Color(0xFFF44336), // Red
+            Color(0xFFE91E63), // Pink
+            Color(0xFF9C27B0), // Purple
+            Color(0xFF673AB7), // Deep Purple
+            Color(0xFF3F51B5), // Indigo
+            Color(0xFF2196F3), // Blue
+            Color(0xFF03A9F4), // Light Blue
+            Color(0xFF00BCD4), // Cyan
+            Color(0xFF009688), // Teal
+            Color(0xFF4CAF50), // Green
+            Color(0xFF8BC34A), // Light Green
+            Color(0xFFCDDC39), // Lime
+            Color(0xFFFFEB3B), // Yellow
+            Color(0xFFFFC107), // Amber
+            Color(0xFFFF9800), // Orange
+            Color(0xFFFF5722), // Deep Orange
+            Color(0xFF795548), // Brown
+            Color(0xFF607D8B), // Blue Grey
+        )
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = "Custom Color") },
+        text = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                // Preview Box
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(60.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(currentColor)
+                        .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(12.dp))
+                )
+
+                // Presets
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    items(presets) { color ->
+                        Box(
+                            modifier = Modifier
+                                .size(32.dp)
+                                .clip(CircleShape)
+                                .background(color)
+                                .border(
+                                    width = if (color == currentColor) 2.dp else 0.dp,
+                                    color = if (color == currentColor) MaterialTheme.colorScheme.onSurface else Color.Transparent,
+                                    shape = CircleShape
+                                )
+                                .clickable {
+                                    val hsv = FloatArray(3)
+                                    AndroidColor.colorToHSV(color.toArgb(), hsv)
+                                    hue = hsv[0]
+                                    saturation = hsv[1]
+                                    value = hsv[2]
+                                }
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // Sliders
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Text(text = "Hue: ${hue.roundToInt()}°", style = MaterialTheme.typography.labelMedium)
+                    Slider(
+                        value = hue,
+                        onValueChange = { hue = it },
+                        valueRange = 0f..360f
+                    )
+
+                    Text(text = "Saturation: ${(saturation * 100).roundToInt()}%", style = MaterialTheme.typography.labelMedium)
+                    Slider(
+                        value = saturation,
+                        onValueChange = { saturation = it },
+                        valueRange = 0f..1f
+                    )
+
+                    Text(text = "Value: ${(value * 100).roundToInt()}%", style = MaterialTheme.typography.labelMedium)
+                    Slider(
+                        value = value,
+                        onValueChange = { value = it },
+                        valueRange = 0f..1f
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onColorSelected(currentColor) }) {
+                Text(stringResource(android.R.string.ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.cancel))
+            }
+        },
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    )
+}

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AppearanceSettings.kt
@@ -6,10 +6,12 @@
 package com.metrolist.music.ui.screens.settings
 
 import android.os.Build
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -20,7 +22,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -46,6 +51,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -54,6 +62,7 @@ import androidx.navigation.NavController
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.R
 import com.metrolist.music.constants.ChipSortTypeKey
+import com.metrolist.music.constants.CustomThemeColorKey
 import com.metrolist.music.constants.DarkModeKey
 import com.metrolist.music.constants.DefaultOpenTabKey
 import com.metrolist.music.constants.EnableDynamicIconKey
@@ -92,12 +101,14 @@ import com.metrolist.music.constants.SwipeToSongKey
 import com.metrolist.music.constants.SwipeToRemoveSongKey
 import com.metrolist.music.constants.UseNewMiniPlayerDesignKey
 import com.metrolist.music.constants.UseNewPlayerDesignKey
+import com.metrolist.music.ui.component.ColorPickerDialog
 import com.metrolist.music.ui.component.DefaultDialog
 import com.metrolist.music.ui.component.EnumDialog
 import com.metrolist.music.ui.component.IconButton
 import com.metrolist.music.ui.component.Material3SettingsGroup
 import com.metrolist.music.ui.component.Material3SettingsItem
 import com.metrolist.music.ui.component.PlayerSliderTrack
+import com.metrolist.music.ui.theme.DefaultThemeColor
 import com.metrolist.music.ui.theme.PlayerSliderColors
 import com.metrolist.music.ui.utils.backToMain
 import com.metrolist.music.utils.IconUtils
@@ -126,6 +137,12 @@ fun AppearanceSettings(
         DynamicThemeKey,
         defaultValue = true
     )
+    val (customThemeColor, onCustomThemeColorChange) = rememberPreference(
+        CustomThemeColorKey,
+        defaultValue = DefaultThemeColor.toArgb()
+    )
+    var showColorPicker by remember { mutableStateOf(false) }
+
     val (enableDynamicIcon, onEnableDynamicIconChange) = rememberPreference(
         EnableDynamicIconKey,
         defaultValue = true
@@ -304,6 +321,17 @@ fun AppearanceSettings(
 
     var showLyricsLineSpacingDialog by rememberSaveable {
         mutableStateOf(false)
+    }
+
+    if (showColorPicker) {
+        ColorPickerDialog(
+            initialColor = Color(customThemeColor),
+            onDismiss = { showColorPicker = false },
+            onColorSelected = {
+                onCustomThemeColorChange(it.toArgb())
+                showColorPicker = false
+            }
+        )
     }
 
     if (showLyricsPositionDialog) {
@@ -854,6 +882,73 @@ fun AppearanceSettings(
                             )
                         },
                         onClick = { onDynamicThemeChange(!dynamicTheme) }
+                    )
+                )
+                add(
+                    Material3SettingsItem(
+                        icon = painterResource(R.drawable.palette),
+                        title = { Text(stringResource(R.string.theme_color)) },
+                        description = {
+                            val presets = remember {
+                                listOf(
+                                    Color(0xFFED5564), // Default
+                                    Color(0xFFF44336), // Red
+                                    Color(0xFFFF9800), // Orange
+                                    Color(0xFFFFEB3B), // Yellow
+                                    Color(0xFF4CAF50), // Green
+                                    Color(0xFF2196F3), // Blue
+                                    Color(0xFF9C27B0), // Purple
+                                    Color(0xFFE91E63), // Pink
+                                )
+                            }
+                            LazyRow(
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                modifier = Modifier.padding(top = 8.dp)
+                            ) {
+                                items(presets) { color ->
+                                    Box(
+                                        modifier = Modifier
+                                            .size(32.dp)
+                                            .clip(CircleShape)
+                                            .background(color)
+                                            .border(
+                                                width = if (color.toArgb() == customThemeColor) 2.dp else 0.dp,
+                                                color = if (color.toArgb() == customThemeColor) MaterialTheme.colorScheme.onSurface else Color.Transparent,
+                                                shape = CircleShape
+                                            )
+                                            .clickable { onCustomThemeColorChange(color.toArgb()) }
+                                    )
+                                }
+                                item {
+                                    Box(
+                                        contentAlignment = Alignment.Center,
+                                        modifier = Modifier
+                                            .size(32.dp)
+                                            .clip(CircleShape)
+                                            .background(
+                                                Brush.sweepGradient(
+                                                    listOf(
+                                                        Color.Red,
+                                                        Color.Green,
+                                                        Color.Blue,
+                                                        Color.Red
+                                                    )
+                                                )
+                                            )
+                                            .clickable { showColorPicker = true }
+                                    ) {
+                                        if (presets.none { it.toArgb() == customThemeColor }) {
+                                            Box(
+                                                modifier = Modifier
+                                                    .size(8.dp)
+                                                    .clip(CircleShape)
+                                                    .background(Color.White)
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     )
                 )
                 add(

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -278,6 +278,7 @@
     <string name="lyrics_offset">Lyrics Offset</string>
 
     <!-- Material 3 Settings Sections -->
+    <string name="theme_color">Theme color</string>
     <string name="settings_section_ui">Interface</string>
     <string name="settings_section_privacy">Privacy &amp; Security</string>
     <string name="settings_section_player">Player &amp; Media</string>


### PR DESCRIPTION
This PR adds a feature to allow users to select a custom "base" theme color for the application.

Previously, if Dynamic Theme was disabled or no song was playing, the app would revert to a hardcoded default color. Now, users can choose a color from a list of rainbow presets or use a custom color picker (HSV sliders) to define their preferred base color.

This custom color is used:
1. When "Dynamic Theme" is disabled.
2. When the music player is idle (no song loaded).
3. When album art color extraction fails or is unavailable.

This enhances personalization options for users who prefer a static theme or a specific brand color.

---
*PR created automatically by Jules for task [2699556207086118439](https://jules.google.com/task/2699556207086118439) started by @adrielGGmotion*