### PR TITLE
Fix music stop on unlock and buffering issues

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -718,8 +718,8 @@ class MusicService :
 
             AudioManager.AUDIOFOCUS_LOSS -> {
                 hasAudioFocus = false
-                wasPlayingBeforeAudioFocusLoss = player.isPlaying
                 if (player.isPlaying) {
+                    wasPlayingBeforeAudioFocusLoss = true
                     player.pause()
                 }
                 abandonAudioFocus()
@@ -728,8 +728,8 @@ class MusicService :
 
             AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
                 hasAudioFocus = false
-                wasPlayingBeforeAudioFocusLoss = player.isPlaying
                 if (player.isPlaying) {
+                    wasPlayingBeforeAudioFocusLoss = true
                     player.pause()
                 }
                 lastAudioFocusState = focusChange
@@ -737,8 +737,8 @@ class MusicService :
 
             AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
                 hasAudioFocus = false
-                wasPlayingBeforeAudioFocusLoss = player.isPlaying
                 if (player.isPlaying) {
+                    wasPlayingBeforeAudioFocusLoss = true
                     player.volume = (playerVolume.value * 0.2f)
                 }
                 lastAudioFocusState = focusChange


### PR DESCRIPTION
This change fixes an issue where music playback would stop suddenly when unlocking the phone or during specific buffering scenarios on Pixel 9 (Android 16). 

The root cause was a race condition in `handleAudioFocusChange`. When multiple transient focus loss events occurred in quick succession, the `wasPlayingBeforeAudioFocusLoss` flag was unconditionally updated to the current `player.isPlaying` state. If the player was already paused by the first event, the second event would overwrite the flag to `false`, preventing the app from resuming playback when focus was regained.

The fix ensures `wasPlayingBeforeAudioFocusLoss` is only updated to `true` if the player is currently playing, preserving the resume intent during overlapping focus loss events.

---
*PR created automatically by Jules for task [15857672458169717871](https://jules.google.com/task/15857672458169717871) started by @adrielGGmotion*