### PR TITLE
Implement partial local music support

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/constants/LibraryFilter.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/LibraryFilter.kt
@@ -11,4 +11,5 @@ enum class LibraryFilter {
     ALBUMS,
     PLAYLISTS,
     LIBRARY,
+    LOCAL,
 }

--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -162,6 +162,8 @@ val QueueEditLockKey = booleanPreferencesKey("queueEditLock")
 val ShowWrappedCardKey = booleanPreferencesKey("show_wrapped_card")
 val WrappedSeenKey = booleanPreferencesKey("wrapped_seen")
 
+val LocalFoldersKey = androidx.datastore.preferences.core.stringSetPreferencesKey("localFolders")
+
 val ShowLikedPlaylistKey = booleanPreferencesKey("show_liked_playlist")
 val ShowDownloadedPlaylistKey = booleanPreferencesKey("show_downloaded_playlist")
 val ShowTopPlaylistKey = booleanPreferencesKey("show_top_playlist")
@@ -184,7 +186,8 @@ enum class SongFilter {
     LIBRARY,
     LIKED,
     DOWNLOADED,
-    UPLOADED
+    UPLOADED,
+    LOCAL
 }
 
 enum class ArtistFilter {

--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -1059,14 +1059,14 @@ interface DatabaseDao {
     ) = when (sortType) {
         SongSortType.CREATE_DATE -> localSongsByCreateDateAsc()
         SongSortType.NAME ->
-            localSongsByNameAsc().map { songs ->
+            localSongsByCreateDateAsc().map { songs ->
                 val collator = Collator.getInstance(Locale.getDefault())
                 collator.strength = Collator.PRIMARY
                 songs.sortedWith(compareBy(collator) { it.song.title })
             }
 
         SongSortType.ARTIST ->
-            localSongsByNameAsc().map { songs ->
+            localSongsByCreateDateAsc().map { songs ->
                 val collator = Collator.getInstance(Locale.getDefault())
                 collator.strength = Collator.PRIMARY
                 songs.sortedWith(compareBy(collator) { song ->

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -70,6 +70,7 @@ import androidx.media3.exoplayer.audio.DefaultAudioSink
 import androidx.media3.exoplayer.audio.SilenceSkippingAudioProcessor
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.ShuffleOrder.DefaultShuffleOrder
+import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.extractor.ExtractorsFactory
 import androidx.media3.extractor.mkv.MatroskaExtractor
 import androidx.media3.extractor.mp4.FragmentedMp4Extractor
@@ -2233,9 +2234,7 @@ class MusicService :
     private fun createMediaSourceFactory() =
         DefaultMediaSourceFactory(
             createDataSourceFactory(),
-            ExtractorsFactory {
-                arrayOf(MatroskaExtractor(), FragmentedMp4Extractor())
-            },
+            DefaultExtractorsFactory(),
         )
 
     private fun createRenderersFactory() =

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/NavigationBuilder.kt
@@ -320,6 +320,10 @@ fun NavGraphBuilder.navigationBuilder(
         ContentSettings(navController, scrollBehavior)
     })
 
+    composable(route = "settings/content/local_music", content = {
+        com.metrolist.music.ui.screens.settings.LocalMusicSettings(navController, scrollBehavior)
+    })
+
     composable(route = "settings/content/romanization", content = {
         RomanizationSettings(navController, scrollBehavior)
     })

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryScreen.kt
@@ -33,6 +33,7 @@ fun LibraryScreen(navController: NavController) {
                     LibraryFilter.SONGS to stringResource(R.string.filter_songs),
                     LibraryFilter.ALBUMS to stringResource(R.string.filter_albums),
                     LibraryFilter.ARTISTS to stringResource(R.string.filter_artists),
+                    LibraryFilter.LOCAL to stringResource(R.string.filter_local),
                 ),
                 currentValue = filterType,
                 onValueUpdate = {
@@ -65,6 +66,12 @@ fun LibraryScreen(navController: NavController) {
             LibraryFilter.ARTISTS -> LibraryArtistsScreen(
                 navController,
                 { filterType = LibraryFilter.LIBRARY })
+
+            LibraryFilter.LOCAL -> com.metrolist.music.ui.screens.library.LibrarySongsScreen(
+                navController,
+                { filterType = LibraryFilter.LIBRARY },
+                initialFilter = com.metrolist.music.constants.SongFilter.LOCAL
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
@@ -156,6 +156,7 @@ fun LibrarySongsScreen(
                             // Uploaded feature is temporarily disabled
                             // SongFilter.UPLOADED to stringResource(R.string.filter_uploaded),
                             SongFilter.DOWNLOADED to stringResource(R.string.filter_downloaded),
+                            SongFilter.LOCAL to "Local",
                         ),
                         currentValue = filter,
                         onValueUpdate = {

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
@@ -156,7 +156,7 @@ fun LibrarySongsScreen(
                             // Uploaded feature is temporarily disabled
                             // SongFilter.UPLOADED to stringResource(R.string.filter_uploaded),
                             SongFilter.DOWNLOADED to stringResource(R.string.filter_downloaded),
-                            SongFilter.LOCAL to "Local",
+                            SongFilter.LOCAL to stringResource(R.string.filter_local),
                         ),
                         currentValue = filter,
                         onValueUpdate = {

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
@@ -71,6 +71,7 @@ fun LibrarySongsScreen(
     navController: NavController,
     onDeselect: () -> Unit,
     viewModel: LibrarySongsViewModel = hiltViewModel(),
+    initialFilter: SongFilter? = null
 ) {
     val context = LocalContext.current
     val menuState = LocalMenuState.current
@@ -90,6 +91,12 @@ fun LibrarySongsScreen(
     val songs by viewModel.allSongs.collectAsState()
 
     var filter by rememberEnumPreference(SongFilterKey, SongFilter.LIKED)
+
+    LaunchedEffect(initialFilter) {
+        if (initialFilter != null) {
+            filter = initialFilter
+        }
+    }
 
     LaunchedEffect(Unit) {
         if (ytmSync) {

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AppearanceSettings.kt
@@ -582,6 +582,7 @@ fun AppearanceSettings(
                     LibraryFilter.ALBUMS -> stringResource(R.string.albums)
                     LibraryFilter.PLAYLISTS -> stringResource(R.string.playlists)
                     LibraryFilter.LIBRARY -> stringResource(R.string.filter_library)
+                    LibraryFilter.LOCAL -> stringResource(R.string.filter_local)
                 }
             }
         )
@@ -1312,6 +1313,7 @@ fun AppearanceSettings(
                                 LibraryFilter.ALBUMS -> stringResource(R.string.albums)
                                 LibraryFilter.PLAYLISTS -> stringResource(R.string.playlists)
                                 LibraryFilter.LIBRARY -> stringResource(R.string.filter_library)
+                                LibraryFilter.LOCAL -> stringResource(R.string.filter_local)
                             }
                         )
                     },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ContentSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ContentSettings.kt
@@ -392,6 +392,11 @@ fun ContentSettings(
             title = stringResource(R.string.general),
             items = listOf(
                 Material3SettingsItem(
+                    icon = painterResource(R.drawable.library_music),
+                    title = { Text("Local Music") },
+                    onClick = { navController.navigate("settings/content/local_music") }
+                ),
+                Material3SettingsItem(
                     icon = painterResource(R.drawable.language),
                     title = { Text(stringResource(R.string.content_language)) },
                     description = {

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ContentSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ContentSettings.kt
@@ -393,7 +393,7 @@ fun ContentSettings(
             items = listOf(
                 Material3SettingsItem(
                     icon = painterResource(R.drawable.library_music),
-                    title = { Text("Local Music") },
+                    title = { Text(stringResource(R.string.local_music)) },
                     onClick = { navController.navigate("settings/content/local_music") }
                 ),
                 Material3SettingsItem(

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/LocalMusicSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/LocalMusicSettings.kt
@@ -1,0 +1,134 @@
+package com.metrolist.music.ui.screens.settings
+
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import com.metrolist.music.LocalPlayerAwareWindowInsets
+import com.metrolist.music.R
+import com.metrolist.music.constants.LocalFoldersKey
+import com.metrolist.music.ui.component.IconButton
+import com.metrolist.music.ui.component.Material3SettingsGroup
+import com.metrolist.music.ui.component.Material3SettingsItem
+import com.metrolist.music.ui.utils.backToMain
+import com.metrolist.music.utils.rememberPreference
+import com.metrolist.music.viewmodels.LocalMusicViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LocalMusicSettings(
+    navController: NavController,
+    scrollBehavior: TopAppBarScrollBehavior,
+    viewModel: LocalMusicViewModel = hiltViewModel()
+) {
+    val context = LocalContext.current
+    val (localFolders, onLocalFoldersChange) = rememberPreference(LocalFoldersKey, emptySet())
+
+    val folderPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocumentTree()
+    ) { uri: Uri? ->
+        if (uri != null) {
+            context.contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            )
+            val newFolders = localFolders + uri.toString()
+            onLocalFoldersChange(newFolders)
+        }
+    }
+
+    Column(
+        Modifier
+            .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp),
+    ) {
+        Material3SettingsGroup(
+            title = "Manage Folders",
+            items = buildList {
+                add(
+                    Material3SettingsItem(
+                        icon = painterResource(R.drawable.library_add),
+                        title = { Text("Add Folder") },
+                        onClick = { folderPickerLauncher.launch(null) }
+                    )
+                )
+                if (localFolders.isNotEmpty()) {
+                    add(
+                        Material3SettingsItem(
+                            icon = painterResource(R.drawable.sync),
+                            title = { Text("Scan Now") },
+                            onClick = { viewModel.scanLocalFiles(localFolders) }
+                        )
+                    )
+                }
+            }
+        )
+
+        if (localFolders.isNotEmpty()) {
+            Material3SettingsGroup(
+                title = "Added Folders",
+                items = localFolders.map { uriString ->
+                    Material3SettingsItem(
+                        icon = painterResource(R.drawable.library_music),
+                        title = { Text(Uri.parse(uriString).lastPathSegment ?: uriString) },
+                        trailingContent = {
+                            androidx.compose.material3.IconButton(
+                                onClick = {
+                                    val newFolders = localFolders - uriString
+                                    onLocalFoldersChange(newFolders)
+                                    try {
+                                        context.contentResolver.releasePersistableUriPermission(
+                                            Uri.parse(uriString),
+                                            Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                                        )
+                                    } catch (e: Exception) {
+                                        // Ignore
+                                    }
+                                }
+                            ) {
+                                Icon(
+                                    painter = painterResource(R.drawable.close),
+                                    contentDescription = "Remove"
+                                )
+                            }
+                        }
+                    )
+                }
+            )
+        }
+    }
+
+    TopAppBar(
+        title = { Text("Local Music") },
+        navigationIcon = {
+            IconButton(
+                onClick = navController::navigateUp,
+                onLongClick = navController::backToMain,
+            ) {
+                Icon(
+                    painterResource(R.drawable.arrow_back),
+                    contentDescription = null,
+                )
+            }
+        },
+        scrollBehavior = scrollBehavior
+    )
+}

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/LocalMusicSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/LocalMusicSettings.kt
@@ -61,12 +61,12 @@ fun LocalMusicSettings(
             .padding(horizontal = 16.dp),
     ) {
         Material3SettingsGroup(
-            title = "Manage Folders",
+            title = androidx.compose.ui.res.stringResource(R.string.manage_folders),
             items = buildList {
                 add(
                     Material3SettingsItem(
                         icon = painterResource(R.drawable.library_add),
-                        title = { Text("Add Folder") },
+                        title = { Text(androidx.compose.ui.res.stringResource(R.string.add_folder)) },
                         onClick = { folderPickerLauncher.launch(null) }
                     )
                 )
@@ -74,7 +74,7 @@ fun LocalMusicSettings(
                     add(
                         Material3SettingsItem(
                             icon = painterResource(R.drawable.sync),
-                            title = { Text("Scan Now") },
+                            title = { Text(androidx.compose.ui.res.stringResource(R.string.scan_now)) },
                             onClick = { viewModel.scanLocalFiles(localFolders) }
                         )
                     )
@@ -84,7 +84,7 @@ fun LocalMusicSettings(
 
         if (localFolders.isNotEmpty()) {
             Material3SettingsGroup(
-                title = "Added Folders",
+                title = androidx.compose.ui.res.stringResource(R.string.added_folders),
                 items = localFolders.map { uriString ->
                     Material3SettingsItem(
                         icon = painterResource(R.drawable.library_music),
@@ -100,7 +100,7 @@ fun LocalMusicSettings(
                                             Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
                                         )
                                     } catch (e: Exception) {
-                                        // Ignore
+                                        timber.log.Timber.w(e, "Failed to release persistable URI permission for %s", uriString)
                                     }
                                 }
                             ) {
@@ -117,7 +117,7 @@ fun LocalMusicSettings(
     }
 
     TopAppBar(
-        title = { Text("Local Music") },
+        title = { Text(androidx.compose.ui.res.stringResource(R.string.local_music)) },
         navigationIcon = {
             IconButton(
                 onClick = navController::navigateUp,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/LocalMusicSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/LocalMusicSettings.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -17,6 +18,8 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -40,6 +43,7 @@ fun LocalMusicSettings(
 ) {
     val context = LocalContext.current
     val (localFolders, onLocalFoldersChange) = rememberPreference(LocalFoldersKey, emptySet())
+    val isScanning by viewModel.isScanning.collectAsState()
 
     val folderPickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocumentTree()
@@ -75,7 +79,12 @@ fun LocalMusicSettings(
                         Material3SettingsItem(
                             icon = painterResource(R.drawable.sync),
                             title = { Text(androidx.compose.ui.res.stringResource(R.string.scan_now)) },
-                            onClick = { viewModel.scanLocalFiles(localFolders) }
+                            onClick = { viewModel.scanLocalFiles(localFolders) },
+                            trailingContent = {
+                                if (isScanning) {
+                                    CircularProgressIndicator()
+                                }
+                            }
                         )
                     )
                 }

--- a/app/src/main/kotlin/com/metrolist/music/utils/LocalMusicScanner.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/LocalMusicScanner.kt
@@ -67,15 +67,22 @@ class LocalMusicScanner @Inject constructor(
             // DocumentFile uri works with MediaMetadataRetriever setDataSource(Context, Uri)
             retriever.setDataSource(context, uri)
 
-            val title = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_TITLE) ?: file.name?.substringBeforeLast('.') ?: "Unknown Title"
-            val artist = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ARTIST) ?: "Unknown Artist"
-            val album = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ALBUM) ?: "Unknown Album"
+            val title = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_TITLE)
+                ?.takeIf { it.isNotBlank() }
+                ?: file.name?.substringBeforeLast('.')
+                ?: "Unknown Title"
+            val artist = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ARTIST)
+                ?.takeIf { it.isNotBlank() }
+                ?: "Unknown Artist"
+            val album = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ALBUM)
+                ?.takeIf { it.isNotBlank() }
+                ?: "Unknown Album"
             val durationStr = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
             val durationMs = durationStr?.toLongOrNull() ?: 0L
             val yearStr = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_YEAR)
             val year = yearStr?.toIntOrNull()
             val trackNumberStr = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_CD_TRACK_NUMBER)
-            val trackNumber = trackNumberStr?.split("/")?.firstOrNull()?.toIntOrNull() ?: 0
+            val trackNumber = trackNumberStr?.split("/")?.firstOrNull()?.trim()?.toIntOrNull() ?: 0
 
             LocalSongData(
                 uri = uri.toString(),

--- a/app/src/main/kotlin/com/metrolist/music/utils/LocalMusicScanner.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/LocalMusicScanner.kt
@@ -1,0 +1,207 @@
+package com.metrolist.music.utils
+
+import android.content.Context
+import android.media.MediaMetadataRetriever
+import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
+import com.metrolist.music.db.MusicDatabase
+import com.metrolist.music.db.entities.AlbumArtistMap
+import com.metrolist.music.db.entities.AlbumEntity
+import com.metrolist.music.db.entities.ArtistEntity
+import com.metrolist.music.db.entities.SongAlbumMap
+import com.metrolist.music.db.entities.SongArtistMap
+import com.metrolist.music.db.entities.SongEntity
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.time.LocalDateTime
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class LocalMusicScanner @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val database: MusicDatabase
+) {
+    private val supportedExtensions = setOf("mp3", "m4a", "flac", "wav", "ogg", "opus")
+
+    suspend fun scanLocalFiles(folderUris: Set<String>) = withContext(Dispatchers.IO) {
+        Timber.d("Scanning local files from ${folderUris.size} folders")
+
+        val allSongs = mutableListOf<LocalSongData>()
+
+        folderUris.forEach { uriString ->
+            try {
+                val uri = Uri.parse(uriString)
+                val folder = DocumentFile.fromTreeUri(context, uri)
+                if (folder != null && folder.exists()) {
+                    scanFolder(folder, allSongs)
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Error scanning folder: $uriString")
+            }
+        }
+
+        saveToDatabase(allSongs)
+    }
+
+    private fun scanFolder(folder: DocumentFile, songs: MutableList<LocalSongData>) {
+        folder.listFiles().forEach { file ->
+            if (file.isDirectory) {
+                scanFolder(file, songs)
+            } else {
+                val ext = file.name?.substringAfterLast('.', "")?.lowercase()
+                if (ext in supportedExtensions) {
+                    processFile(file)?.let { songs.add(it) }
+                }
+            }
+        }
+    }
+
+    private fun processFile(file: DocumentFile): LocalSongData? {
+        val uri = file.uri
+        val retriever = MediaMetadataRetriever()
+        return try {
+            // DocumentFile uri works with MediaMetadataRetriever setDataSource(Context, Uri)
+            retriever.setDataSource(context, uri)
+
+            val title = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_TITLE) ?: file.name?.substringBeforeLast('.') ?: "Unknown Title"
+            val artist = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ARTIST) ?: "Unknown Artist"
+            val album = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ALBUM) ?: "Unknown Album"
+            val durationStr = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+            val durationMs = durationStr?.toLongOrNull() ?: 0L
+            val yearStr = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_YEAR)
+            val year = yearStr?.toIntOrNull()
+            val trackNumberStr = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_CD_TRACK_NUMBER)
+            val trackNumber = trackNumberStr?.split("/")?.firstOrNull()?.toIntOrNull() ?: 0
+
+            LocalSongData(
+                uri = uri.toString(),
+                title = title,
+                artist = artist,
+                album = album,
+                durationSeconds = (durationMs / 1000).toInt(),
+                year = year,
+                trackNumber = trackNumber
+            )
+        } catch (e: Exception) {
+            Timber.e(e, "Error processing file: ${file.uri}")
+            null
+        } finally {
+            try {
+                retriever.release()
+            } catch (e: Exception) {
+                // Ignore
+            }
+        }
+    }
+
+    private suspend fun saveToDatabase(songs: List<LocalSongData>) {
+        songs.forEach { songData ->
+            try {
+                database.withTransaction {
+                    // 1. Insert/Update Artist
+                    val artistId = "local:${songData.artist}"
+                    val existingArtist = database.artist(artistId).firstOrNull()?.artist
+
+                    if (existingArtist == null) {
+                        database.insert(
+                            ArtistEntity(
+                                id = artistId,
+                                name = songData.artist,
+                                isLocal = true,
+                                lastUpdateTime = LocalDateTime.now()
+                            )
+                        )
+                    }
+
+                    // 2. Insert/Update Album
+                    val albumId = "local:${songData.album}:${songData.artist}"
+                    val existingAlbum = database.album(albumId).firstOrNull()
+
+                    if (existingAlbum == null) {
+                        database.insert(
+                            AlbumEntity(
+                                id = albumId,
+                                title = songData.album,
+                                year = songData.year,
+                                songCount = 1,
+                                duration = songData.durationSeconds,
+                                isLocal = true,
+                                lastUpdateTime = LocalDateTime.now()
+                            )
+                        )
+                        // Map Album to Artist
+                         database.insert(
+                            AlbumArtistMap(
+                                albumId = albumId,
+                                artistId = artistId,
+                                order = 0
+                            )
+                        )
+                    }
+
+                    // 3. Insert/Update Song
+                    val songId = songData.uri
+                    val existingSong = database.getSongById(songId)
+
+                    val songEntity = SongEntity(
+                        id = songId,
+                        title = songData.title,
+                        duration = songData.durationSeconds,
+                        albumId = albumId,
+                        albumName = songData.album,
+                        year = songData.year,
+                        isLocal = true,
+                        inLibrary = LocalDateTime.now(), // Auto-add to library
+                        dateModified = LocalDateTime.now()
+                    )
+
+                    if (existingSong == null) {
+                        database.insert(songEntity)
+                    } else {
+                        // Preserve user data
+                        database.update(songEntity.copy(
+                            liked = existingSong.song.liked,
+                            likedDate = existingSong.song.likedDate,
+                            totalPlayTime = existingSong.song.totalPlayTime,
+                            inLibrary = existingSong.song.inLibrary ?: LocalDateTime.now() // Ensure it stays in library
+                        ))
+                    }
+
+                    // 4. Map Song to Artist
+                    database.insert(
+                        SongArtistMap(
+                            songId = songId,
+                            artistId = artistId,
+                            position = 0
+                        )
+                    )
+
+                    // 5. Map Song to Album
+                    database.insert(
+                        SongAlbumMap(
+                            songId = songId,
+                            albumId = albumId,
+                            index = songData.trackNumber
+                        )
+                    )
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Error saving song to DB: ${songData.title}")
+            }
+        }
+    }
+
+    data class LocalSongData(
+        val uri: String,
+        val title: String,
+        val artist: String,
+        val album: String,
+        val durationSeconds: Int,
+        val year: Int?,
+        val trackNumber: Int
+    )
+}

--- a/app/src/main/kotlin/com/metrolist/music/utils/LocalMusicScanner.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/LocalMusicScanner.kt
@@ -99,9 +99,9 @@ class LocalMusicScanner @Inject constructor(
     }
 
     private suspend fun saveToDatabase(songs: List<LocalSongData>) {
-        songs.forEach { songData ->
-            try {
-                database.withTransaction {
+        try {
+            database.withTransaction {
+                songs.forEach { songData ->
                     // 1. Insert/Update Artist
                     val artistId = "local:${songData.artist}"
                     val existingArtist = database.artist(artistId).firstOrNull()?.artist
@@ -189,9 +189,9 @@ class LocalMusicScanner @Inject constructor(
                         )
                     )
                 }
-            } catch (e: Exception) {
-                Timber.e(e, "Error saving song to DB: ${songData.title}")
             }
+        } catch (e: Exception) {
+            Timber.e(e, "Error saving local songs to DB")
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/LibraryViewModels.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/LibraryViewModels.kt
@@ -98,6 +98,7 @@ constructor(
                     SongFilter.LIBRARY -> database.songs(sortType, descending).map { it.filterExplicit(hideExplicit).filterVideoSongs(hideVideoSongs) }
                     SongFilter.LIKED -> database.likedSongs(sortType, descending).map { it.filterExplicit(hideExplicit).filterVideoSongs(hideVideoSongs) }
                     SongFilter.DOWNLOADED -> database.downloadedSongs(sortType, descending).map { it.filterExplicit(hideExplicit).filterVideoSongs(hideVideoSongs) }
+                    SongFilter.LOCAL -> database.localSongs(sortType, descending).map { it.filterExplicit(hideExplicit).filterVideoSongs(hideVideoSongs) }
                     // Uploaded feature is temporarily disabled
                     SongFilter.UPLOADED -> kotlinx.coroutines.flow.flowOf(emptyList())
                     // SongFilter.UPLOADED -> database.uploadedSongs(sortType, descending).map { it.filterExplicit(hideExplicit).filterVideoSongs(hideVideoSongs) }

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalMusicViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalMusicViewModel.kt
@@ -1,0 +1,15 @@
+package com.metrolist.music.viewmodels
+
+import androidx.lifecycle.ViewModel
+import com.metrolist.music.utils.SyncUtils
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class LocalMusicViewModel @Inject constructor(
+    private val syncUtils: SyncUtils
+) : ViewModel() {
+    fun scanLocalFiles(uris: Set<String>) {
+        syncUtils.syncLocalFiles(uris)
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalMusicViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalMusicViewModel.kt
@@ -1,14 +1,23 @@
 package com.metrolist.music.viewmodels
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.metrolist.music.utils.SyncStatus
 import com.metrolist.music.utils.SyncUtils
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 @HiltViewModel
 class LocalMusicViewModel @Inject constructor(
     private val syncUtils: SyncUtils
 ) : ViewModel() {
+    val isScanning = syncUtils.syncState
+        .map { it.localFiles is SyncStatus.Syncing }
+        .stateIn(viewModelScope, SharingStarted.Lazily, false)
+
     fun scanLocalFiles(uris: Set<String>) {
         syncUtils.syncLocalFiles(uris)
     }

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -29,6 +29,12 @@
     <string name="cached_playlist">Cached</string>
     <string name="uploaded_playlist">Uploaded</string>
     <string name="filter_uploaded">Uploaded</string>
+    <string name="filter_local">Local</string>
+    <string name="local_music">Local Music</string>
+    <string name="manage_folders">Manage Folders</string>
+    <string name="add_folder">Add Folder</string>
+    <string name="scan_now">Scan Now</string>
+    <string name="added_folders">Added Folders</string>
     <string name="sync_playlist">Sync playlist</string>
     <string name="sync_disabled">Sync disabled</string>
     <string name="elements_selected">%1$d elements selected</string>


### PR DESCRIPTION
This PR implements partial local music support as requested.
It allows users to select folders on their device, scans them for audio files, extracts metadata, and adds them to the library under a new "Local" filter.
Playback logic is updated to handle local file URIs directly, bypassing YouTube resolution.
Note: This is "partial" support; advanced features like metadata editing are not included, and stability relies on Android's MediaMetadataRetriever.

---
*PR created automatically by Jules for task [6154120693263223895](https://jules.google.com/task/6154120693263223895) started by @adrielGGmotion*