### PR TITLE
Feature/devtools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@ Metrolist is a 3rd party YouTube Music client written in Kotlin. It follows mate
 
 1. Always create a new branch for your feature work. Follow these naming conventions:
    - Bug fixes: `fix/short-description`
-   - New features: `feature/short-description`
-   - Refactoring: `refactor/short-description`
+   - New features: `feat/short-description`
+   - Refactoring: `ref/short-description`
    - Documentation: `docs/short-description`
    - Chores: `chore/short-description`
 2. Branch descriptions should be concise yet descriptive enough to understand the purpose of the branch at a glance.
@@ -27,15 +27,16 @@ Metrolist is a 3rd party YouTube Music client written in Kotlin. It follows mate
 4. Ensure the absolutely highest code quality in all contributions, including proper formatting, clear variable naming, and comprehensive comments where necessary.
 5. Comments should be added only for complex logic or non-obvious code. Avoid redundant comments that simply restate what the code does.
 6. Prioritize performance, battery efficiency, and maintainability in all code contributions. Always consider the impact of your changes on the overall user experience and app performance.
-7. If you have any doubts ask a human contributor. This can be done using the `askQuestions` tool if you're running in GitHub Copilot. I don't know if other agents have these type of tools.
+7. If you have any doubts ask a human contributor. Never make assumptions about the requirements or implementation details without clarification.
 8. If you do not test your changes using the instructions in the next section, you will be faced with reprimands from human contributors and may be asked to redo your work. Always ensure that you test your changes thoroughly before asking for a final review.
+9. You are absolutely **not allowed to bump the version** of the app in ANY way. Version bumps are only done by the core development team after manual review.
 
 ## Building and testing your changes
 
 1. After making changes to the code, you should build the app to ensure that there are no compilation errors. Use the following command from the root directory of the project:
 
 ```bash
-./gradlew :app:assembleuniversalFossDebug
+./gradlew :app:assembleFossDebug
 ```
 
 2. If the build is not successful, review the error messages, fix the issues in your code, and try building again.

--- a/app/src/main/kotlin/com/metrolist/music/App.kt
+++ b/app/src/main/kotlin/com/metrolist/music/App.kt
@@ -27,6 +27,7 @@ import com.metrolist.kugou.KuGou
 import com.metrolist.lastfm.LastFM
 import com.metrolist.music.BuildConfig
 import com.metrolist.music.constants.*
+import com.metrolist.music.devtools.DevToolsTimberTree
 import com.metrolist.music.di.ApplicationScope
 import com.metrolist.music.extensions.toEnum
 import com.metrolist.music.extensions.toInetSocketAddress
@@ -58,6 +59,9 @@ class App : Application(), SingletonImageLoader.Factory {
     @ApplicationScope
     lateinit var applicationScope: CoroutineScope
 
+    @Inject
+    lateinit var devToolsTimberTree: DevToolsTimberTree
+
     override fun onCreate() {
         super.onCreate()
 
@@ -67,10 +71,23 @@ class App : Application(), SingletonImageLoader.Factory {
         // Initialize PlayerJsFetcher for n-transform solver
         PlayerJsFetcher.initialize(this)
 
-        Timber.plant(Timber.DebugTree())
+        if (BuildConfig.DEBUG) {
+            Timber.plant(Timber.DebugTree())
+        }
 
         // تهيئة إعدادات التطبيق عند الإقلاع
         applicationScope.launch {
+            // Only plant DevTools Timber tree if developer mode is enabled.
+            // Don't block/abort the rest of startup if this read fails.
+            val devModeEnabled = runCatching {
+                dataStore.data.first()[DeveloperModeKey] ?: false
+            }.getOrElse {
+                Timber.w(it, "Failed to read DeveloperModeKey; continuing startup")
+                false
+            }
+            if (devModeEnabled) {
+                Timber.plant(devToolsTimberTree)
+            }
             initializeSettings()
             observeSettingsChanges()
         }
@@ -222,9 +239,6 @@ class App : Application(), SingletonImageLoader.Factory {
     }
 
     override fun newImageLoader(context: PlatformContext): ImageLoader {
-        val cacheSize = runBlocking {
-            dataStore.data.map { it[MaxImageCacheSizeKey] ?: 512 }.first()
-        }
         return ImageLoader.Builder(this).apply {
             crossfade(true)
             allowHardware(Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
@@ -234,16 +248,12 @@ class App : Application(), SingletonImageLoader.Factory {
                     .maxSizePercent(context, 0.25)
                     .build()
             }
-            if (cacheSize == 0) {
-                diskCachePolicy(CachePolicy.DISABLED)
-            } else {
-                diskCache(
-                    DiskCache.Builder()
-                        .directory(cacheDir.resolve("coil"))
-                        .maxSizeBytes(cacheSize * 1024 * 1024L)
-                        .build()
-                )
-            }
+            diskCache(
+                DiskCache.Builder()
+                    .directory(cacheDir.resolve("coil"))
+                    .maxSizeBytes(512 * 1024 * 1024L)
+                    .build()
+            )
         }.build()
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -69,6 +69,8 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import com.metrolist.music.devtools.DevToolsLogBuffer
+import com.metrolist.music.devtools.ui.DevToolsOverlay
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.derivedStateOf
@@ -129,6 +131,7 @@ import com.metrolist.music.constants.AppLanguageKey
 import com.metrolist.music.constants.CheckForUpdatesKey
 import com.metrolist.music.constants.DarkModeKey
 import com.metrolist.music.constants.DefaultOpenTabKey
+import com.metrolist.music.constants.DeveloperModeKey
 import com.metrolist.music.constants.DisableScreenshotKey
 import com.metrolist.music.constants.DynamicThemeKey
 import com.metrolist.music.constants.EnableHighRefreshRateKey
@@ -225,6 +228,9 @@ class MainActivity : ComponentActivity() {
 
     @Inject
     lateinit var listenTogetherManager: com.metrolist.music.listentogether.ListenTogetherManager
+
+    @Inject
+    lateinit var devToolsLogBuffer: DevToolsLogBuffer
 
     private lateinit var navController: NavHostController
     private var pendingIntent: Intent? = null
@@ -356,7 +362,7 @@ class MainActivity : ComponentActivity() {
     }
 
     @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
-    @OptIn(ExperimentalMaterial3Api::class)
+    @OptIn(ExperimentalMaterial3Api::class, androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class)
     @Composable
     private fun MetrolistApp(
         latestVersionName: String,
@@ -454,6 +460,7 @@ class MainActivity : ComponentActivity() {
         val pureBlack = remember(pureBlackEnabled, useDarkTheme) {
             pureBlackEnabled && useDarkTheme
         }
+        val devMode by rememberPreference(DeveloperModeKey, defaultValue = false)
 
         val (selectedThemeColorInt) = rememberPreference(SelectedThemeColorKey, defaultValue = DefaultThemeColor.toArgb())
         val selectedThemeColor = Color(selectedThemeColorInt)
@@ -1136,6 +1143,13 @@ class MainActivity : ComponentActivity() {
                                 homeViewModel.refresh()
                             },
                             latestVersionName = latestVersionName
+                        )
+                    }
+
+                    if (devMode) {
+                        DevToolsOverlay(
+                            logBuffer = devToolsLogBuffer,
+                            isPlayerExpanded = playerBottomSheetState.isExpanded
                         )
                     }
 

--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -1727,6 +1727,18 @@ interface DatabaseDao {
     @RawQuery
     fun raw(supportSQLiteQuery: SupportSQLiteQuery): Int
 
+    @Query("SELECT COUNT(*) FROM song")
+    fun devCountSongs(): Flow<Int>
+
+    @Query("SELECT COUNT(*) FROM album")
+    fun devCountAlbums(): Flow<Int>
+
+    @Query("SELECT COUNT(*) FROM artist")
+    fun devCountArtists(): Flow<Int>
+
+    @Query("SELECT COUNT(*) FROM playlist")
+    fun devCountPlaylists(): Flow<Int>
+
     fun checkpoint() {
         raw("PRAGMA wal_checkpoint(FULL)".toSQLiteQuery())
     }

--- a/app/src/main/kotlin/com/metrolist/music/db/MusicDatabase.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/MusicDatabase.kt
@@ -59,6 +59,9 @@ class MusicDatabase(
     val openHelper: SupportSQLiteOpenHelper
         get() = delegate.openHelper
 
+    val isOpen: Boolean
+        get() = delegate.isOpen
+
     fun query(block: MusicDatabase.() -> Unit) =
         with(delegate) {
             queryExecutor.execute {

--- a/app/src/main/kotlin/com/metrolist/music/devtools/DevToolsLog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/devtools/DevToolsLog.kt
@@ -1,0 +1,28 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.devtools
+
+import android.util.Log
+
+data class DevToolsLog(
+    val id: Long = System.nanoTime(),
+    val timestamp: Long = System.currentTimeMillis(),
+    val priority: Int,
+    val tag: String,
+    val message: String,
+    val throwable: String? = null
+) {
+    val priorityLabel: String
+        get() = when (priority) {
+            Log.VERBOSE -> "V"
+            Log.DEBUG -> "D"
+            Log.INFO -> "I"
+            Log.WARN -> "W"
+            Log.ERROR -> "E"
+            Log.ASSERT -> "A"
+            else -> "?"
+        }
+}

--- a/app/src/main/kotlin/com/metrolist/music/devtools/DevToolsLogBuffer.kt
+++ b/app/src/main/kotlin/com/metrolist/music/devtools/DevToolsLogBuffer.kt
@@ -1,0 +1,60 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.devtools
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+class DevToolsLogBuffer(private val maxSize: Int = 1000) {
+    init {
+        require(maxSize > 0) { "maxSize must be positive, got $maxSize" }
+    }
+    private val buffer = arrayOfNulls<DevToolsLog>(maxSize)
+    private var index = 0
+    private var isFull = false
+    private val lock = ReentrantLock()
+
+    private val _logs = MutableStateFlow<List<DevToolsLog>>(emptyList())
+    val logs: StateFlow<List<DevToolsLog>> = _logs.asStateFlow()
+
+    private fun getSnapshotLocked(): List<DevToolsLog> {
+        val size = if (isFull) maxSize else index
+        val result = ArrayList<DevToolsLog>(size)
+        if (isFull) {
+            for (i in index until maxSize) {
+                buffer[i]?.let { result.add(it) }
+            }
+        }
+        for (i in 0 until index) {
+            buffer[i]?.let { result.add(it) }
+        }
+        return result
+    }
+
+    fun add(log: DevToolsLog) {
+        lock.withLock {
+            buffer[index] = log
+            index++
+            if (index >= maxSize) {
+                index = 0
+                isFull = true
+            }
+            _logs.value = getSnapshotLocked()
+        }
+    }
+
+    fun clear() {
+        lock.withLock {
+            buffer.fill(null)
+            index = 0
+            isFull = false
+            _logs.value = emptyList()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/devtools/DevToolsTimberTree.kt
+++ b/app/src/main/kotlin/com/metrolist/music/devtools/DevToolsTimberTree.kt
@@ -1,0 +1,23 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.devtools
+
+import timber.log.Timber
+
+class DevToolsTimberTree(
+    private val buffer: DevToolsLogBuffer
+) : Timber.DebugTree() {
+
+    override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+        val log = DevToolsLog(
+            priority = priority,
+            tag = tag ?: "Unknown",
+            message = message,
+            throwable = t?.stackTraceToString()
+        )
+        buffer.add(log)
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/devtools/ui/ActionsPanel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/devtools/ui/ActionsPanel.kt
@@ -1,0 +1,252 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.devtools.ui
+
+import android.content.Intent
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.metrolist.music.R
+import coil3.imageLoader
+import com.metrolist.music.devtools.DevToolsLogBuffer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.regex.Pattern
+
+private val logTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.systemDefault())
+
+private val SENSITIVE_PATTERNS = listOf(
+    Pattern.compile("([Aa]uth|[Tt]oken)[=:]\\s*[\\w\\-]{10,}", Pattern.CASE_INSENSITIVE),
+    Pattern.compile("(cookie|session)[=:]\\s*[\\w\\-]{10,}", Pattern.CASE_INSENSITIVE),
+    Pattern.compile("(visitorData)[=:]\\s*[\\w\\-]{20,}", Pattern.CASE_INSENSITIVE),
+    Pattern.compile("(dataSyncId)[=:]\\s*[\\w\\-]{20,}", Pattern.CASE_INSENSITIVE),
+    Pattern.compile("(SAPISID)[=:]\\s*[\\w\\-]{20,}", Pattern.CASE_INSENSITIVE),
+    Pattern.compile("(__Secure-[A-Z]+)[=:]\\s*[\\w\\-]{10,}", Pattern.CASE_INSENSITIVE),
+)
+
+private fun redactSensitiveData(text: String): String {
+    var result = text
+    for (pattern in SENSITIVE_PATTERNS) {
+        result = pattern.matcher(result).replaceAll("$1=<REDACTED>")
+    }
+    return result
+}
+
+@Composable
+fun ActionsPanel(buffer: DevToolsLogBuffer) {
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        PanelHeader(
+            title = stringResource(R.string.dev_actions),
+            subtitle = stringResource(R.string.dev_actions_subtitle)
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            
+            ActionCard(
+                title = stringResource(R.string.export_logs),
+                description = stringResource(R.string.export_logs_desc),
+                buttonText = stringResource(R.string.export_now),
+                iconRes = R.drawable.share,
+                onClick = {
+                    coroutineScope.launch {
+                        try {
+                            val logs = buffer.logs.value
+                            val runtime = Runtime.getRuntime()
+                            val actManager = context.getSystemService(android.content.Context.ACTIVITY_SERVICE) as android.app.ActivityManager
+                            val memInfo = android.app.ActivityManager.MemoryInfo().apply { actManager.getMemoryInfo(this) }
+                            val totalRamGb = memInfo.totalMem / 1024 / 1024 / 1024
+                            val availRamGb = memInfo.availMem / 1024 / 1024 / 1024
+                            val maxHeapMb = runtime.maxMemory() / 1024 / 1024
+                            val displayMetrics = context.resources.displayMetrics
+                            val resolution = "${displayMetrics.widthPixels}x${displayMetrics.heightPixels}"
+                            val density = displayMetrics.densityDpi
+                            
+                            val envHeader = context.getString(
+                                R.string.dev_export_header,
+                                com.metrolist.music.BuildConfig.VERSION_NAME,
+                                com.metrolist.music.BuildConfig.VERSION_CODE.toString(),
+                                if (com.metrolist.music.BuildConfig.DEBUG) context.getString(R.string.dev_debug) else context.getString(R.string.dev_release),
+                                com.metrolist.music.BuildConfig.ARCHITECTURE,
+                                android.os.Build.MANUFACTURER,
+                                android.os.Build.MODEL,
+                                android.os.Build.VERSION.RELEASE,
+                                android.os.Build.VERSION.SDK_INT.toString(),
+                                resolution,
+                                density.toString(),
+                                availRamGb.toString(),
+                                totalRamGb.toString(),
+                                maxHeapMb.toString()
+                            )
+        
+                            val uri = withContext(Dispatchers.IO) {
+                                val file = java.io.File(context.cacheDir, context.getString(R.string.dev_export_filename, System.currentTimeMillis().toString()))
+                                file.bufferedWriter().use { writer ->
+                                    writer.write(envHeader)
+                                    logs.forEach { log ->
+                                        val redactedMessage = redactSensitiveData(log.message)
+                                        val redactedThrowable = log.throwable?.let { redactSensitiveData(it) }
+                                        writer.write("${logTimeFormatter.format(Instant.ofEpochMilli(log.timestamp))} ${log.priorityLabel}/${log.tag}: $redactedMessage${redactedThrowable?.let { t -> "\n$t" } ?: ""}\n")
+                                    }
+                                }
+                                androidx.core.content.FileProvider.getUriForFile(context, "${context.packageName}.FileProvider", file)
+                            }
+                            
+                            val sendIntent: Intent = Intent().apply {
+                                action = Intent.ACTION_SEND
+                                putExtra(Intent.EXTRA_STREAM, uri)
+                                type = "text/plain"
+                                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                            }
+                            val shareIntent = Intent.createChooser(sendIntent, context.getString(R.string.export_devtools_logs))
+                            context.startActivity(shareIntent)
+                        } catch (e: Exception) {
+                            Toast.makeText(context, context.getString(R.string.export_failed, e.message), Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                }
+            )
+
+            ActionCard(
+                title = stringResource(R.string.clear_cache),
+                description = stringResource(R.string.clear_cache_desc),
+                buttonText = stringResource(R.string.clear_cache),
+                iconRes = R.drawable.delete,
+                isDestructive = true,
+                onClick = {
+                    coroutineScope.launch {
+                        try {
+                            val sizeMb = withContext(Dispatchers.IO) {
+                                val size = context.cacheDir.walkTopDown().filter { it.isFile }.map { it.length() }.sum()
+                                val files = context.cacheDir.listFiles()
+                                var allDeleted = true
+                                files?.forEach { if (!it.deleteRecursively()) allDeleted = false }
+                                if (!allDeleted) {
+                                    // Some files couldn't be deleted, but we continue
+                                }
+                                size / 1024 / 1024
+                            }
+                            Toast.makeText(context, context.getString(R.string.cleared_cache_mb, sizeMb), Toast.LENGTH_SHORT).show()
+                        } catch (e: Exception) {
+                            Toast.makeText(context, context.getString(R.string.failed_clear_cache, e.message), Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                }
+            )
+
+            ActionCard(
+                title = stringResource(R.string.dev_clear_image_cache),
+                description = stringResource(R.string.dev_clear_image_cache_desc),
+                buttonText = stringResource(R.string.dev_clear_image_cache),
+                iconRes = R.drawable.delete,
+                isDestructive = true,
+                onClick = {
+                    coroutineScope.launch(Dispatchers.IO) {
+                        try {
+                            context.imageLoader.memoryCache?.clear()
+                            context.imageLoader.diskCache?.clear()
+                            withContext(Dispatchers.Main) {
+                                Toast.makeText(context, context.getString(R.string.dev_cleared_image_cache), Toast.LENGTH_SHORT).show()
+                            }
+                        } catch (e: Exception) {
+                            withContext(Dispatchers.Main) {
+                                Toast.makeText(context, context.getString(R.string.failed_clear_cache, e.message), Toast.LENGTH_SHORT).show()
+                            }
+                        }
+                    }
+                }
+            )
+        }
+    }
+}
+
+@OptIn(androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun ActionCard(
+    title: String,
+    description: String,
+    buttonText: String,
+    iconRes: Int,
+    isDestructive: Boolean = false,
+    onClick: () -> Unit
+) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp, bottom = 16.dp)
+            )
+            
+            val colors = if (isDestructive) {
+                ButtonDefaults.filledTonalButtonColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer
+                )
+            } else {
+                ButtonDefaults.filledTonalButtonColors()
+            }
+
+            FilledTonalButton(
+                onClick = onClick,
+                colors = colors,
+                modifier = Modifier.align(Alignment.End)
+            ) {
+                Icon(
+                    painter = painterResource(id = iconRes),
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(buttonText)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/devtools/ui/DatabaseInfoPanel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/devtools/ui/DatabaseInfoPanel.kt
@@ -1,0 +1,66 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.devtools.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.metrolist.music.R
+import com.metrolist.music.LocalDatabase
+import java.text.NumberFormat
+import java.util.Locale
+
+@Composable
+fun DatabaseInfoPanel() {
+    val database = LocalDatabase.current
+    val numberFormat = remember { NumberFormat.getNumberInstance(Locale.getDefault()) }
+    
+    val songCount by database.devCountSongs().collectAsState(initial = 0)
+    val albumCount by database.devCountAlbums().collectAsState(initial = 0)
+    val artistCount by database.devCountArtists().collectAsState(initial = 0)
+    val playlistCount by database.devCountPlaylists().collectAsState(initial = 0)
+
+    val dbName = remember { database.openHelper.databaseName ?: "Unknown" }
+    val isDbOpen = remember { database.isOpen }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        PanelHeader(
+            title = stringResource(R.string.database),
+            subtitle = stringResource(R.string.database_subtitle)
+        )
+        
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            item {
+                InfoCard(title = stringResource(R.string.connection)) {
+                    InfoRow(stringResource(R.string.database_name), dbName)
+                    InfoRow(stringResource(R.string.status), if (isDbOpen) stringResource(R.string.dev_db_connected) else stringResource(R.string.dev_db_disconnected))
+                }
+            }
+            item {
+                InfoCard(title = stringResource(R.string.library_stats)) {
+                    InfoRow(stringResource(R.string.songs), numberFormat.format(songCount))
+                    InfoRow(stringResource(R.string.albums), numberFormat.format(albumCount))
+                    InfoRow(stringResource(R.string.artists), numberFormat.format(artistCount))
+                    InfoRow(stringResource(R.string.playlists), numberFormat.format(playlistCount))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/devtools/ui/DevToolsOverlay.kt
+++ b/app/src/main/kotlin/com/metrolist/music/devtools/ui/DevToolsOverlay.kt
@@ -1,0 +1,180 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.devtools.ui
+
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.LinearWavyProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.metrolist.music.R
+import com.metrolist.music.constants.DeveloperModeKey
+import com.metrolist.music.devtools.DevToolsLogBuffer
+import com.metrolist.music.utils.rememberPreference
+import kotlin.math.roundToInt
+
+@Composable
+private fun DevToolsFabBottomPadding(): androidx.compose.ui.unit.Dp {
+    return dimensionResource(R.dimen.devtools_fab_bottom_padding)
+}
+
+@OptIn(ExperimentalMaterial3Api::class, androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun PanelHeader(title: String, subtitle: String? = null) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 24.dp, end = 24.dp, top = 24.dp, bottom = 12.dp)
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineLarge,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.Bold
+        )
+        if (subtitle != null) {
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        LinearWavyProgressIndicator(
+            progress = { 1f },
+            amplitude = { 1f },
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
+fun DevToolsOverlay(
+    logBuffer: DevToolsLogBuffer,
+    isPlayerExpanded: Boolean
+) {
+    val devMode by rememberPreference(DeveloperModeKey, defaultValue = false)
+    if (!devMode) return
+
+    if (isPlayerExpanded) return
+
+    val configuration = androidx.compose.ui.platform.LocalConfiguration.current
+    val density = androidx.compose.ui.platform.LocalDensity.current
+
+    val screenWidthPx = with(density) { configuration.screenWidthDp.dp.toPx() }
+    val screenHeightPx = with(density) { configuration.screenHeightDp.dp.toPx() }
+    val context = androidx.compose.ui.platform.LocalContext.current
+    val dragBoundsPaddingPx = with(density) { context.resources.getDimension(R.dimen.devtools_drag_bounds_padding).toDp().toPx() }
+
+    var isPanelExpanded by remember { mutableStateOf(false) }
+    var offsetX by rememberSaveable { mutableFloatStateOf(0f) }
+    var offsetY by rememberSaveable { mutableFloatStateOf(0f) }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        FloatingActionButton(
+            onClick = { isPanelExpanded = true },
+            modifier = Modifier
+                .offset { IntOffset(offsetX.roundToInt(), offsetY.roundToInt()) }
+                .pointerInput(Unit) {
+                    detectDragGestures { change, dragAmount ->
+                        change.consume()
+                        val minX = (-screenWidthPx + dragBoundsPaddingPx).coerceAtMost(0f)
+                        offsetX = (offsetX + dragAmount.x).coerceIn(minX, 0f)
+                        val boundY = (screenHeightPx / 2f - dragBoundsPaddingPx).coerceAtLeast(0f)
+                        offsetY = (offsetY + dragAmount.y).coerceIn(-boundY, boundY)
+                    }
+                }
+                .align(Alignment.CenterEnd)
+                .padding(end = 16.dp, bottom = DevToolsFabBottomPadding()),
+            containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.8f)
+        ) {
+            Icon(
+                painterResource(R.drawable.bug_report),
+                contentDescription = stringResource(R.string.dev_tools)
+            )
+        }
+    }
+
+    if (isPanelExpanded) {
+        Dialog(
+            onDismissRequest = { isPanelExpanded = false },
+            properties = DialogProperties(
+                dismissOnBackPress = true,
+                dismissOnClickOutside = true,
+                usePlatformDefaultWidth = false
+            )
+        ) {
+            Surface(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .systemBarsPadding()
+                    .padding(top = 40.dp)
+                    .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)),
+                color = MaterialTheme.colorScheme.surface
+            ) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    var selectedTab by remember { mutableIntStateOf(0) }
+                    val tabs = listOf(stringResource(R.string.dev_tab_logs), stringResource(R.string.dev_tab_player), stringResource(R.string.dev_tab_db), stringResource(R.string.dev_tab_tools))
+
+                    PrimaryTabRow(selectedTabIndex = selectedTab) {
+                        tabs.forEachIndexed { index, title ->
+                            Tab(
+                                selected = selectedTab == index,
+                                onClick = { selectedTab = index },
+                                text = { Text(title) }
+                            )
+                        }
+                    }
+
+                    Box(modifier = Modifier.weight(1f)) {
+                        when (selectedTab) {
+                            0 -> LogViewerPanel(logBuffer)
+                            1 -> PlayerStatePanel()
+                            2 -> DatabaseInfoPanel()
+                            3 -> ActionsPanel(logBuffer)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/devtools/ui/LogViewerPanel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/devtools/ui/LogViewerPanel.kt
@@ -1,0 +1,469 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.devtools.ui
+
+import androidx.compose.runtime.produceState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import android.util.Log
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.input.clearText
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SearchBar
+import androidx.compose.material3.SearchBarDefaults
+import androidx.compose.material3.SearchBarValue
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.SmallFloatingActionButton
+import androidx.compose.material3.rememberSearchBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.metrolist.music.R
+import com.metrolist.music.devtools.DevToolsLog
+import com.metrolist.music.devtools.DevToolsLogBuffer
+import kotlinx.coroutines.launch
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val logTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS").withZone(ZoneId.systemDefault())
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LogViewerPanel(buffer: DevToolsLogBuffer) {
+    val logs by buffer.logs.collectAsState()
+    
+    var selectedLevels by remember { mutableStateOf(setOf<Int>()) }
+    var selectedTagGroups by remember { mutableStateOf(setOf<String>()) }
+    val selectedLogIdsState = remember { mutableStateOf(setOf<Long>()) }
+    var selectedLogIds by selectedLogIdsState
+    var showFilters by remember { mutableStateOf(false) }
+    val clipboard = LocalClipboard.current
+
+    val onToggleLog = remember {
+        { logId: Long ->
+            val current = selectedLogIdsState.value
+            selectedLogIdsState.value = if (logId in current) current - logId else current + logId
+        }
+    }
+
+    val searchBarState = rememberSearchBarState(initialValue = SearchBarValue.Expanded)
+    val textFieldState = rememberTextFieldState()
+    val scope = rememberCoroutineScope()
+    val listState = rememberLazyListState()
+
+    val tagPlayer = stringResource(R.string.dev_filter_player)
+    val tagUi = stringResource(R.string.dev_filter_ui)
+    val tagDb = stringResource(R.string.dev_filter_db)
+    val tagIntegration = stringResource(R.string.dev_filter_integration)
+
+    val query = textFieldState.text.toString()
+    val filteredLogs by produceState(
+        initialValue = emptyList<DevToolsLog>(),
+        logs, selectedLevels, selectedTagGroups, query, tagPlayer, tagUi, tagDb, tagIntegration
+    ) {
+        value = withContext(Dispatchers.Default) {
+            logs.filter { log ->
+                val levelMatch = selectedLevels.isEmpty() || log.priority in selectedLevels
+                val tagMatch = selectedTagGroups.isEmpty() || selectedTagGroups.any { group ->
+                    when (group) {
+                        tagPlayer -> log.tag.contains("Player") || log.tag.contains("ExoPlayer") || log.tag.contains("MusicService")
+                        tagUi -> log.tag.contains("Screen") || log.tag.contains("Activity")
+                        tagDb -> log.tag.contains("Room") || log.tag.contains("Database") || log.tag.contains("Dao")
+                        tagIntegration -> log.tag.contains("Discord") || log.tag.contains("LastFM") || log.tag.contains("Kizzy")
+                        else -> false
+                    }
+                }
+                val textMatch = query.isBlank() ||
+                    log.message.contains(query, ignoreCase = true) ||
+                    log.tag.contains(query, ignoreCase = true) ||
+                    (log.throwable?.contains(query, ignoreCase = true) == true)
+                levelMatch && tagMatch && textMatch
+            }
+        }
+    }
+    
+    val isAtBottom by remember {
+        derivedStateOf {
+            val visibleItemsInfo = listState.layoutInfo.visibleItemsInfo
+            if (visibleItemsInfo.isEmpty()) {
+                true
+            } else {
+                val lastVisibleItem = visibleItemsInfo.last()
+                lastVisibleItem.index >= listState.layoutInfo.totalItemsCount - 3
+            }
+        }
+    }
+
+    LaunchedEffect(logs) {
+        val currentIds = logs.map { it.id }.toSet()
+        if (selectedLogIds.any { it !in currentIds }) {
+            selectedLogIds = selectedLogIds.intersect(currentIds)
+        }
+    }
+
+    LaunchedEffect(filteredLogs.lastOrNull()?.id) {
+        if (filteredLogs.isNotEmpty() && isAtBottom) {
+            listState.scrollToItem(filteredLogs.lastIndex)
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            PanelHeader(title = stringResource(R.string.logs), subtitle = stringResource(R.string.logs_subtitle))
+
+            SearchBar(
+                state = searchBarState,
+                inputField = {
+                    SearchBarDefaults.InputField(
+                        textFieldState = textFieldState,
+                        searchBarState = searchBarState,
+                        onSearch = { scope.launch { searchBarState.animateToCollapsed() } },
+                        placeholder = { Text(stringResource(R.string.search_logs)) },
+                        leadingIcon = {
+                            Icon(
+                                painterResource(R.drawable.search),
+                                contentDescription = stringResource(R.string.search_logs)
+                            )
+                        },
+                        trailingIcon = {
+                            if (textFieldState.text.isNotEmpty()) {
+                                IconButton(onClick = { textFieldState.clearText() }) {
+                                    Icon(
+                                        painterResource(R.drawable.close),
+                                        contentDescription = stringResource(R.string.clear_search)
+                                    )
+                                }
+                            }
+                        }
+                    )
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 4.dp)
+            )
+
+            AnimatedVisibility(visible = selectedLogIds.isNotEmpty()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.primaryContainer)
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = stringResource(R.string.selected_count, selectedLogIds.size),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        modifier = Modifier.weight(1f)
+                    )
+                    IconButton(onClick = {
+                        val logsToCopy = logs.filter { it.id in selectedLogIds }
+                        val text = logsToCopy.joinToString("\n\n") { log ->
+                            "${logTimeFormatter.format(Instant.ofEpochMilli(log.timestamp))} ${log.priorityLabel}/${log.tag}\n${log.message}${log.throwable?.let { "\n$it" } ?: ""}"
+                        }
+                        scope.launch {
+                            clipboard.setClipEntry(androidx.compose.ui.platform.ClipEntry(
+                                android.content.ClipData.newPlainText("logs", text)
+                            ))
+                        }
+                        selectedLogIds = emptySet()
+                    }) {
+                        Icon(painterResource(R.drawable.content_copy), contentDescription = stringResource(R.string.copy_selected), tint = MaterialTheme.colorScheme.onPrimaryContainer)
+                    }
+                    IconButton(onClick = { selectedLogIds = emptySet() }) {
+                        Icon(painterResource(R.drawable.close), contentDescription = stringResource(R.string.clear_selection), tint = MaterialTheme.colorScheme.onPrimaryContainer)
+                    }
+                }
+            }
+            
+            AnimatedVisibility(visible = showFilters) {
+                ElevatedCard(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Column(modifier = Modifier.padding(vertical = 8.dp)) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .horizontalScroll(rememberScrollState())
+                                .padding(horizontal = 12.dp, vertical = 4.dp),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            FilterChip(
+                                selected = selectedLevels.isEmpty(),
+                                onClick = { selectedLevels = emptySet() },
+                                label = { Text(stringResource(R.string.all_levels)) }
+                            )
+                            val levels = listOf(
+                                Log.VERBOSE to stringResource(R.string.log_verbose),
+                                Log.DEBUG to stringResource(R.string.log_debug),
+                                Log.INFO to stringResource(R.string.log_info),
+                                Log.WARN to stringResource(R.string.log_warn),
+                                Log.ERROR to stringResource(R.string.log_error)
+                            )
+                            levels.forEach { (level, name) ->
+                                FilterChip(
+                                    selected = level in selectedLevels,
+                                    onClick = { 
+                                        selectedLevels = if (level in selectedLevels) {
+                                            selectedLevels - level
+                                        } else {
+                                            selectedLevels + level
+                                        }
+                                    },
+                                    label = { Text(name) }
+                                )
+                            }
+                        }
+                        
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .horizontalScroll(rememberScrollState())
+                                .padding(horizontal = 12.dp, vertical = 4.dp),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            FilterChip(
+                                selected = selectedTagGroups.isEmpty(),
+                                onClick = { selectedTagGroups = emptySet() },
+                                label = { Text(stringResource(R.string.all_tags)) }
+                            )
+                            listOf(tagPlayer, tagUi, tagDb, tagIntegration).forEach { group ->
+                                FilterChip(
+                                    selected = group in selectedTagGroups,
+                                    onClick = { 
+                                        selectedTagGroups = if (group in selectedTagGroups) {
+                                            selectedTagGroups - group
+                                        } else {
+                                            selectedTagGroups + group
+                                        }
+                                    },
+                                    label = { Text(group) }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+            
+            if (filteredLogs.isEmpty()) {
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(bottom = 80.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = stringResource(R.string.dev_empty),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            } else {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp),
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(top = 8.dp, bottom = 80.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(filteredLogs, key = { it.id }) { log ->
+                        val isSelected = log.id in selectedLogIds
+                        LogRow(
+                            log = log,
+                            isSelected = isSelected,
+                            onToggleSelect = onToggleLog
+                        )
+                    }
+                }
+            }
+        }
+        
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            SmallFloatingActionButton(
+                onClick = { showFilters = !showFilters },
+                containerColor = if (showFilters) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceVariant
+            ) {
+                Icon(
+                    painterResource(R.drawable.tune), 
+                    contentDescription = stringResource(R.string.toggle_filters),
+                    tint = if (showFilters) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            
+            SmallFloatingActionButton(
+                onClick = { 
+                    buffer.clear()
+                    selectedLogIdsState.value = emptySet()
+                },
+                containerColor = MaterialTheme.colorScheme.errorContainer
+            ) {
+                Icon(
+                    painterResource(R.drawable.delete), 
+                    contentDescription = stringResource(R.string.clear_logs),
+                    tint = MaterialTheme.colorScheme.onErrorContainer
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun LogRow(log: DevToolsLog, isSelected: Boolean, onToggleSelect: (Long) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    
+    val color = when (log.priority) {
+        Log.VERBOSE -> MaterialTheme.colorScheme.outline
+        Log.DEBUG -> MaterialTheme.colorScheme.primary
+        Log.INFO -> MaterialTheme.colorScheme.secondary
+        Log.WARN -> MaterialTheme.colorScheme.tertiary
+        Log.ERROR, Log.ASSERT -> MaterialTheme.colorScheme.error
+        else -> MaterialTheme.colorScheme.primary
+    }
+    
+    val timeStr = remember(log.timestamp) {
+        logTimeFormatter.format(Instant.ofEpochMilli(log.timestamp))
+    }
+
+    ElevatedCard(
+        shape = RoundedCornerShape(12.dp),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Surface(
+            color = if (isSelected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f) else MaterialTheme.colorScheme.surface,
+            modifier = Modifier.clickable { expanded = !expanded }
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(IntrinsicSize.Min)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .width(6.dp)
+                        .fillMaxHeight()
+                        .background(color)
+                )
+                
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 12.dp, vertical = 10.dp)
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = timeStr,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 11.sp,
+                            fontFamily = FontFamily.Monospace,
+                            maxLines = 1
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            text = log.tag,
+                            color = color,
+                            fontSize = 12.sp,
+                            fontFamily = FontFamily.Monospace,
+                            fontWeight = FontWeight.Bold,
+                            maxLines = 1
+                        )
+                        
+                        Spacer(Modifier.weight(1f))
+                        
+                        IconButton(
+                            onClick = { onToggleSelect(log.id) },
+                            modifier = Modifier.size(48.dp)
+                        ) {
+                            Icon(
+                                painter = painterResource(if (isSelected) R.drawable.check else R.drawable.radio_button_unchecked),
+                                contentDescription = stringResource(R.string.select_log),
+                                tint = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(20.dp)
+                            )
+                        }
+                    }
+                    
+                    Spacer(modifier = Modifier.height(4.dp))
+                    
+                    SelectionContainer {
+                        Column {
+                            Text(
+                                text = log.message,
+                                color = MaterialTheme.colorScheme.onSurface,
+                                fontSize = 13.sp,
+                                fontFamily = FontFamily.Monospace,
+                                lineHeight = 18.sp,
+                                maxLines = if (expanded) Int.MAX_VALUE else 3
+                            )
+                            if (expanded && log.throwable != null) {
+                                Text(
+                                    text = log.throwable,
+                                    color = MaterialTheme.colorScheme.error,
+                                    fontSize = 11.sp,
+                                    fontFamily = FontFamily.Monospace,
+                                    modifier = Modifier.padding(top = 8.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/devtools/ui/PlayerStatePanel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/devtools/ui/PlayerStatePanel.kt
@@ -1,0 +1,209 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.devtools.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.runtime.DisposableEffect
+import androidx.media3.common.C
+import androidx.media3.common.Player
+import androidx.media3.common.Timeline
+import androidx.media3.common.MediaItem
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.metrolist.music.LocalPlayerConnection
+import com.metrolist.music.R
+import androidx.compose.ui.res.stringResource
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.metrolist.music.devtools.ui.InfoCard
+import com.metrolist.music.devtools.ui.InfoRow
+import kotlinx.coroutines.delay
+
+@Composable
+fun PlayerStatePanel() {
+    val playerConnection = LocalPlayerConnection.current
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        PanelHeader(
+            title = stringResource(R.string.dev_playback),
+            subtitle = stringResource(R.string.dev_playback_subtitle)
+        )
+
+        if (playerConnection == null) {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp),
+            ) {
+                item { 
+                    InfoCard(title = stringResource(R.string.dev_player_status)) {
+                        InfoRow(stringResource(R.string.dev_player_service), stringResource(R.string.dev_player_not_initialized)) 
+                    }
+                }
+            }
+            return
+        }
+
+        val playbackState by playerConnection.playbackState.collectAsState()
+        val isPlaying by playerConnection.isPlaying.collectAsState()
+        val error by playerConnection.error.collectAsState()
+        val currentSong by playerConnection.currentSong.collectAsState(initial = null)
+        
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            item {
+                InfoCard(title = stringResource(R.string.dev_engine_state)) {
+                    InfoRow(stringResource(R.string.dev_service_ready), playerConnection.service.isPlayerReady.value.toString())
+                    InfoRow(stringResource(R.string.dev_playback_state), playbackState.toString())
+                    InfoRow(stringResource(R.string.dev_is_playing), isPlaying.toString())
+                    InfoRow(stringResource(R.string.dev_active_error), error?.message ?: stringResource(R.string.dev_none))
+                }
+            }
+            item {
+                InfoCard(title = stringResource(R.string.dev_current_media)) {
+                    InfoRow(stringResource(R.string.dev_media_id), currentSong?.id ?: stringResource(R.string.dev_none))
+                    InfoRow(stringResource(R.string.dev_title), currentSong?.title ?: stringResource(R.string.dev_none))
+                    TimelineRow(playerConnection)
+                }
+            }
+            item {
+                InfoCard(title = stringResource(R.string.dev_background_processes)) {
+                    InfoRow(stringResource(R.string.dev_discord_rpc), (playerConnection.service.discordRpc != null).toString())
+                    InfoRow(stringResource(R.string.dev_scrobbling), (playerConnection.service.scrobbleManager != null).toString())
+                    InfoRow(stringResource(R.string.dev_crossfade_enabled), playerConnection.service.crossfadeEnabled.toString())
+                    InfoRow(stringResource(R.string.dev_loudness_enhancer), (playerConnection.service.loudnessEnhancer != null).toString())
+                    InfoRow(stringResource(R.string.dev_sleep_timer_active), playerConnection.service.sleepTimer.isActive.toString())
+                }
+            }
+            item {
+                InfoCard(title = stringResource(R.string.dev_listen_together)) {
+                    val ltManager = playerConnection.service.listenTogetherManager
+                    val roomState by ltManager.roomState.collectAsState()
+                    val role by ltManager.role.collectAsState()
+                    val connectionState by ltManager.connectionState.collectAsState()
+                    
+                    val roomCode = roomState?.roomCode ?: stringResource(R.string.dev_none)
+                    
+                    InfoRow(stringResource(R.string.dev_listen_together_status), connectionState.name)
+                    InfoRow(stringResource(R.string.dev_listen_together_room), roomCode)
+                    InfoRow(stringResource(R.string.dev_listen_together_role), role.name)
+                }
+            }
+            item {
+                InfoCard(title = stringResource(R.string.dev_queue_viewer)) {
+                    QueueViewerRow(playerConnection)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun QueueViewerRow(playerConnection: com.metrolist.music.playback.PlayerConnection) {
+    var upcomingItems by remember { androidx.compose.runtime.mutableStateOf<List<String>>(emptyList()) }
+    
+    val fallbackUnknown = stringResource(R.string.dev_unknown)
+    val updateQueue = {
+        val player = playerConnection.player
+        val currentIndex = player.currentMediaItemIndex
+        val items = mutableListOf<String>()
+        for (i in 1..5) {
+            val index = currentIndex + i
+            if (index < player.mediaItemCount) {
+                val item = player.getMediaItemAt(index)
+                items.add(item.mediaMetadata.title?.toString() ?: fallbackUnknown)
+            }
+        }
+        upcomingItems = items
+    }
+
+    DisposableEffect(playerConnection.player) {
+        val listener = object : Player.Listener {
+            override fun onTimelineChanged(timeline: Timeline, reason: Int) {
+                updateQueue()
+            }
+            override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+                updateQueue()
+            }
+        }
+        playerConnection.player.addListener(listener)
+        updateQueue()
+        onDispose { playerConnection.player.removeListener(listener) }
+    }
+    
+    if (upcomingItems.isEmpty()) {
+        InfoRow(stringResource(R.string.dev_queue_viewer_subtitle), stringResource(R.string.dev_empty))
+    } else {
+        InfoRow(stringResource(R.string.dev_queue_viewer_subtitle), "")
+        upcomingItems.forEachIndexed { index, title ->
+            InfoRow("+${index + 1}", title)
+        }
+    }
+}
+
+@Composable
+fun TimelineRow(playerConnection: com.metrolist.music.playback.PlayerConnection) {
+    var currentPosition by remember { mutableLongStateOf(0L) }
+    var duration by remember { mutableLongStateOf(0L) }
+    var queueSize by remember { mutableIntStateOf(0) }
+    val isPlaying by playerConnection.isPlaying.collectAsState()
+    
+    DisposableEffect(playerConnection.player) {
+        val listener = object : Player.Listener {
+            override fun onTimelineChanged(timeline: Timeline, reason: Int) {
+                duration = playerConnection.player.duration
+                queueSize = playerConnection.player.mediaItemCount
+            }
+            override fun onPlaybackStateChanged(state: Int) {
+                duration = playerConnection.player.duration
+            }
+            override fun onPositionDiscontinuity(
+                oldPosition: Player.PositionInfo,
+                newPosition: Player.PositionInfo,
+                reason: Int
+            ) {
+                currentPosition = playerConnection.player.currentPosition
+            }
+        }
+        playerConnection.player.addListener(listener)
+        currentPosition = playerConnection.player.currentPosition
+        duration = playerConnection.player.duration
+        queueSize = playerConnection.player.mediaItemCount
+        
+        onDispose { playerConnection.player.removeListener(listener) }
+    }
+    
+    LaunchedEffect(isPlaying, playerConnection.player) {
+        if (isPlaying) {
+            while (isPlaying) {
+                currentPosition = playerConnection.player.currentPosition
+                delay(1000L)
+            }
+        } else {
+            currentPosition = playerConnection.player.currentPosition
+        }
+    }
+    
+    val posFormatted = if (currentPosition == C.TIME_UNSET) 0L else currentPosition
+    val durFormatted = if (duration == C.TIME_UNSET) 0L else duration
+
+    InfoRow(stringResource(R.string.dev_queue_size), queueSize.toString())
+    InfoRow(stringResource(R.string.dev_timeline), stringResource(R.string.dev_timeline_format, posFormatted, durFormatted))
+}

--- a/app/src/main/kotlin/com/metrolist/music/devtools/ui/SharedDevToolsUI.kt
+++ b/app/src/main/kotlin/com/metrolist/music/devtools/ui/SharedDevToolsUI.kt
@@ -1,0 +1,52 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.devtools.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun InfoCard(title: String, content: @Composable () -> Unit) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(bottom = 12.dp)
+            )
+            content()
+        }
+    }
+}
+
+@Composable
+fun InfoRow(label: String, value: String, modifier: Modifier = Modifier) {
+    Column(modifier = modifier.padding(vertical = 6.dp)) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontFamily = FontFamily.Monospace,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(top = 2.dp)
+        )
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/di/AppModule.kt
+++ b/app/src/main/kotlin/com/metrolist/music/di/AppModule.kt
@@ -15,6 +15,8 @@ import androidx.room.Room
 import com.metrolist.music.constants.MaxSongCacheSizeKey
 import com.metrolist.music.db.InternalDatabase
 import com.metrolist.music.db.MusicDatabase
+import com.metrolist.music.devtools.DevToolsLogBuffer
+import com.metrolist.music.devtools.DevToolsTimberTree
 import com.metrolist.music.listentogether.ListenTogetherClient
 import com.metrolist.music.listentogether.ListenTogetherManager
 import com.metrolist.music.utils.dataStore
@@ -33,8 +35,17 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object AppModule {
 
-    @Provides
     @Singleton
+    @Provides
+    fun provideDevToolsLogBuffer(): DevToolsLogBuffer = DevToolsLogBuffer(maxSize = 1000)
+
+    @Singleton
+    @Provides
+    fun provideDevToolsTimberTree(buffer: DevToolsLogBuffer): DevToolsTimberTree =
+        DevToolsTimberTree(buffer)
+
+    @Singleton
+    @Provides
     @ApplicationScope
     fun provideApplicationScope(): CoroutineScope {
         return CoroutineScope(SupervisorJob() + Dispatchers.Default)

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -251,7 +251,8 @@ class MusicService :
     private var wasPlayingBeforeVolumeMute = false
     private var isPausedByVolumeMute = false
 
-    private var crossfadeEnabled = false
+    internal var crossfadeEnabled = false
+        private set
     private var crossfadeDuration = 5000f
     private var crossfadeGapless = true
     private var crossfadeTriggerJob: Job? = null
@@ -359,14 +360,18 @@ class MusicService :
 
     private val instantSilenceSkipEnabled = MutableStateFlow(false)
 
-    private var isAudioEffectSessionOpened = false
-    private var loudnessEnhancer: LoudnessEnhancer? = null
-
-    private var discordRpc: DiscordRPC? = null
+    internal var isAudioEffectSessionOpened = false
+        private set
+    internal var loudnessEnhancer: LoudnessEnhancer? = null
+        private set
+ 
+    internal var discordRpc: DiscordRPC? = null
+        private set
     private var lastPlaybackSpeed = 1.0f
     private var discordUpdateJob: kotlinx.coroutines.Job? = null
-
-    private var scrobbleManager: ScrobbleManager? = null
+ 
+    internal var scrobbleManager: ScrobbleManager? = null
+        private set
 
     val automixItems = MutableStateFlow<List<MediaItem>>(emptyList())
 
@@ -402,14 +407,17 @@ class MusicService :
             when (intent.action) {
                 Intent.ACTION_SCREEN_OFF -> {
                     if (!player.isPlaying) {
+                        Timber.tag(TAG).d("Discord RPC: screen off while paused, closing connection")
                         scope.launch(Dispatchers.IO) {
-                            discordRpc?.closeRPC()
+                            runCatching { discordRpc?.closeRPC() }
+                                .onFailure { Timber.tag(TAG).e(it, "Failed to close Discord RPC") }
                         }
                     }
                 }
 
                 Intent.ACTION_SCREEN_ON -> {
                     if (player.isPlaying) {
+                        Timber.tag(TAG).d("Discord RPC: screen on while playing, updating presence")
                         scope.launch {
                             currentSong.value?.let { song ->
                                 updateDiscordRPC(song)
@@ -590,6 +598,7 @@ class MusicService :
                 }
                 // Update Discord RPC when network becomes available
                 if (isConnected && discordRpc != null && player.isPlaying) {
+                    Timber.tag(TAG).d("Discord RPC: network reconnected, refreshing presence")
                     val mediaId = player.currentMetadata?.id
                     if (mediaId != null) {
                         database.song(mediaId).first()?.let { song ->
@@ -759,16 +768,21 @@ class MusicService :
             .distinctUntilChanged()
             .collect(scope) { (key, enabled) ->
                 if (discordRpc?.isRpcRunning() == true) {
-                    discordRpc?.closeRPC()
+                    Timber.tag(TAG).d("Discord RPC: tearing down previous instance")
+                    runCatching { discordRpc?.closeRPC() }
+                        .onFailure { Timber.tag(TAG).e(it, "Failed to close Discord RPC") }
                 }
                 discordRpc = null
                 if (key != null && enabled) {
+                    Timber.tag(TAG).d("Discord RPC: creating instance (token=%s)", DiscordRPC.maskToken(key))
                     discordRpc = DiscordRPC(this, key)
                     if (player.playbackState == Player.STATE_READY && player.playWhenReady) {
                         currentSong.value?.let {
                             updateDiscordRPC(it, true)
                         }
                     }
+                } else {
+                    Timber.tag(TAG).d("Discord RPC: disabled (token=%s, enabled=%s)", key != null, enabled)
                 }
             }
 
@@ -2137,8 +2151,10 @@ class MusicService :
                     Player.EVENT_MEDIA_ITEM_TRANSITION
                 )
             ) {
-                scope.launch {
-                    discordRpc?.close()
+                Timber.tag(TAG).d("Discord RPC: playback stopped, closing presence")
+                scope.launch(Dispatchers.IO) {
+                    runCatching { discordRpc?.closeRPC() }
+                        .onFailure { Timber.tag(TAG).e(it, "Failed to close Discord RPC") }
                 }
             }
         }
@@ -2151,6 +2167,7 @@ class MusicService :
         ) {
             val mediaId = player.currentMetadata?.id
             if (mediaId != null) {
+                Timber.tag(TAG).d("Discord RPC: media transition/play event, updating for mediaId=%s", mediaId)
                 scope.launch {
                     // Fetch song from database to get full info
                     database.song(mediaId).first()?.let { song ->
@@ -2788,6 +2805,7 @@ class MusicService :
     }
 
     private fun updateDiscordRPC(song: Song, showFeedback: Boolean = false) {
+        Timber.tag(TAG).d("updateDiscordRPC: song=\"%s\", showFeedback=%s", song.song.title, showFeedback)
         val useDetails = dataStore.get(DiscordUseDetailsKey, false)
         val advancedMode = dataStore.get(DiscordAdvancedModeKey, false)
 
@@ -2814,6 +2832,7 @@ class MusicService :
                 activityType,
                 activityName
             )?.onFailure {
+                Timber.tag(TAG).w(it, "Discord RPC update failed for \"%s\"", song.song.title)
                 // Rate limited or error
                 if (showFeedback) {
                     Handler(Looper.getMainLooper()).post {
@@ -3106,10 +3125,14 @@ class MusicService :
         if (dataStore.get(PersistentQueueKey, true)) {
             saveQueueToDisk()
         }
-        if (discordRpc?.isRpcRunning() == true) {
-            discordRpc?.closeRPC()
+        discordRpc?.let { rpc ->
+            Timber.tag(TAG).d("Discord RPC: service destroying, closing RPC")
+            discordRpc = null
+            scope.launch(Dispatchers.IO) {
+                runCatching { rpc.closeRPC() }
+                    .onFailure { Timber.tag(TAG).e(it, "Failed to close Discord RPC") }
+            }
         }
-        discordRpc = null
         connectivityObserver.unregister()
         abandonAudioFocus()
         releaseLoudnessEnhancer()

--- a/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
@@ -53,7 +53,7 @@ class PlayerConnection(
     context: Context,
     binder: MusicBinder,
     val database: MusicDatabase,
-    scope: CoroutineScope,
+    val scope: CoroutineScope,
 ) : Player.Listener {
     private companion object {
         private const val TAG = "PlayerConnection"
@@ -441,7 +441,7 @@ class PlayerConnection(
         }.toMap()
     }
 
-    private fun checkAndStartAutomaticSleepTimer(): Boolean {
+    private suspend fun checkAndStartAutomaticSleepTimer(): Boolean {
         return try {
             val sleepTimerEnabled = service.applicationContext.dataStore.get(SleepTimerEnabledKey) ?: false
             Timber.tag(TAG).d("✓ Sleep Timer Check: enabled=$sleepTimerEnabled")
@@ -543,7 +543,9 @@ class PlayerConnection(
 
         // Central sleep timer trigger: fires on every paused -> playing transition,
         if (newPlayWhenReady && !wasPlaying) {
-            checkAndStartAutomaticSleepTimer()
+            scope.launch {
+                checkAndStartAutomaticSleepTimer()
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/NavigationBuilder.kt
@@ -53,6 +53,7 @@ import com.metrolist.music.ui.screens.settings.StorageSettings
 import com.metrolist.music.ui.screens.settings.ThemeScreen
 import com.metrolist.music.ui.screens.settings.UpdaterScreen
 import com.metrolist.music.ui.screens.settings.AiSettings
+import com.metrolist.music.ui.screens.settings.DevToolsSettingsScreen
 import com.metrolist.music.ui.screens.settings.integrations.DiscordSettings
 import com.metrolist.music.ui.screens.settings.integrations.IntegrationScreen
 import com.metrolist.music.ui.screens.settings.integrations.LastFMSettings
@@ -386,6 +387,10 @@ fun NavGraphBuilder.navigationBuilder(
 
     composable("settings/updater") {
         UpdaterScreen(navController, scrollBehavior)
+    }
+
+    composable("settings/devtools") {
+        DevToolsSettingsScreen(navController, scrollBehavior)
     }
 
     composable("settings/about") {

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AboutScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
@@ -80,6 +81,20 @@ import com.metrolist.music.ui.component.Material3SettingsItem
 import com.metrolist.music.ui.utils.backToMain
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+
+import android.widget.Toast
+import androidx.compose.ui.platform.LocalContext
+import androidx.datastore.preferences.core.edit
+import com.metrolist.music.constants.DeveloperModeKey
+import com.metrolist.music.utils.dataStore
+import com.metrolist.music.utils.rememberPreference
+import androidx.compose.runtime.mutableLongStateOf
+
+
+
+private const val DEV_MODE_REQUIRED_TAPS = 9
+private const val DEV_MODE_TAP_TIMEOUT_MS = 2000L
+private const val DEV_MODE_COUNTDOWN_START = 3
 
 private data class Contributor(
     val name: String,
@@ -293,26 +308,48 @@ fun AboutScreen(
     val localSnackbarHostState = remember { SnackbarHostState() }
     val wannaPlayStr = stringResource(R.string.wanna_play_favorite_song)
     val yeahStr = stringResource(R.string.yeah)
-    
-    Box(modifier = Modifier.fillMaxSize()) {
+
+    val context = LocalContext.current
+    var tapCount by remember { mutableIntStateOf(0) }
+    var lastTapTime by remember { mutableLongStateOf(0L) }
+    val isDeveloperModeEnabled by rememberPreference(DeveloperModeKey, defaultValue = false)
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.about)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.arrow_back),
+                            contentDescription = stringResource(R.string.cd_back),
+                        )
+                    }
+                },
+                scrollBehavior = scrollBehavior,
+            )
+        },
+        snackbarHost = {
+            androidx.compose.material3.SnackbarHost(
+                hostState = localSnackbarHostState,
+                modifier = Modifier
+                    .windowInsetsPadding(
+                        LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom)
+                    )
+            )
+        }
+    ) { padding ->
         Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .windowInsetsPadding(
-                    LocalPlayerAwareWindowInsets.current.only(
-                        WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
-                    )
-                )
+                .fillMaxSize()
+                .padding(padding)
                 .verticalScroll(rememberScrollState())
                 .nestedScroll(scrollBehavior.nestedScrollConnection),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Spacer(
-                Modifier.windowInsetsPadding(
-                    LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Top)
-                )
-            )
-    
             Spacer(Modifier.height(16.dp))
     
             Surface(
@@ -330,7 +367,38 @@ fun AboutScreen(
                         modifier = Modifier
                             .size(80.dp)
                             .clip(MaterialShapes.SoftBurst.toShape())
-                            .background(MaterialTheme.colorScheme.primaryContainer),
+                            .background(MaterialTheme.colorScheme.primaryContainer)
+                            .clickable {
+                                if (isDeveloperModeEnabled) {
+                                    Toast.makeText(context, context.getString(R.string.dev_mode_already_enabled), Toast.LENGTH_SHORT).show()
+                                    return@clickable
+                                }
+                                val now = System.currentTimeMillis()
+                                if (now - lastTapTime > DEV_MODE_TAP_TIMEOUT_MS) {
+                                    tapCount = 0
+                                }
+                                lastTapTime = now
+                                tapCount++
+
+                                val remaining = DEV_MODE_REQUIRED_TAPS - tapCount
+                                when {
+                                    remaining in 1..DEV_MODE_COUNTDOWN_START -> {
+                                        Toast.makeText(context, context.resources.getQuantityString(R.plurals.dev_mode_taps_remaining, remaining, remaining), Toast.LENGTH_SHORT).show()
+                                    }
+                                    remaining <= 0 -> {
+                                        tapCount = 0
+                                        lastTapTime = 0L
+                                        coroutineScope.launch {
+                                            try {
+                                                context.dataStore.edit { it[DeveloperModeKey] = true }
+                                                Toast.makeText(context, context.getString(R.string.dev_mode_enabled), Toast.LENGTH_LONG).show()
+                                            } catch (e: Exception) {
+                                                Toast.makeText(context, "Failed to enable developer mode", Toast.LENGTH_SHORT).show()
+                                            }
+                                        }
+                                    }
+                                }
+                            },
                         contentAlignment = Alignment.Center
                     ) {
                         androidx.compose.foundation.Image(
@@ -578,30 +646,5 @@ fun AboutScreen(
             
             Spacer(Modifier.height(40.dp))
         }
-
-        TopAppBar(
-            title = { Text(stringResource(R.string.about)) },
-            navigationIcon = {
-                IconButton(
-                    onClick = navController::navigateUp,
-                    onLongClick = navController::backToMain,
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.arrow_back),
-                        contentDescription = stringResource(R.string.cd_back),
-                    )
-                }
-            },
-            scrollBehavior = scrollBehavior,
-        )
-
-        androidx.compose.material3.SnackbarHost(
-            hostState = localSnackbarHostState,
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .windowInsetsPadding(
-                    LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom)
-                )
-        )
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/DevToolsSettingsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/DevToolsSettingsScreen.kt
@@ -1,0 +1,120 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.ui.screens.settings
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.metrolist.music.LocalPlayerAwareWindowInsets
+import com.metrolist.music.R
+import com.metrolist.music.constants.DeveloperModeKey
+import com.metrolist.music.ui.component.IconButton
+import com.metrolist.music.ui.component.PreferenceEntry
+import com.metrolist.music.ui.component.SwitchPreference
+import com.metrolist.music.ui.utils.backToMain
+import com.metrolist.music.utils.rememberPreference
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DevToolsSettingsScreen(
+    navController: NavController,
+    scrollBehavior: TopAppBarScrollBehavior,
+) {
+    var devMode by rememberPreference(DeveloperModeKey, defaultValue = false)
+
+    if (!devMode) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(stringResource(R.string.dev_mode_required))
+        }
+        return
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.dev_tools)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain
+                    ) {
+                        Icon(
+                            painterResource(R.drawable.arrow_back),
+                            contentDescription = stringResource(R.string.cd_back)
+                        )
+                    }
+                },
+                scrollBehavior = scrollBehavior
+            )
+        }
+    ) { padding ->
+        Column(
+            Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
+                .verticalScroll(rememberScrollState())
+        ) {
+            Spacer(
+                Modifier.windowInsetsPadding(
+                    LocalPlayerAwareWindowInsets.current.only(
+                        WindowInsetsSides.Top
+                    )
+                )
+            )
+
+            SwitchPreference(
+                title = { Text(stringResource(R.string.enable_dev_tools)) },
+                description = stringResource(R.string.enable_dev_tools_desc),
+                icon = { Icon(painterResource(R.drawable.bug_report), null) },
+                checked = devMode,
+                onCheckedChange = { newValue ->
+                    devMode = newValue
+                    if (!newValue) {
+                        navController.navigateUp()
+                    }
+                }
+            )
+
+            PreferenceEntry(
+                title = { Text(stringResource(R.string.test_crash_handler), color = androidx.compose.material3.MaterialTheme.colorScheme.error) },
+                description = stringResource(R.string.test_crash_handler_desc),
+                icon = { Icon(painterResource(R.drawable.bug_report), null, tint = androidx.compose.material3.MaterialTheme.colorScheme.error) },
+                onClick = {
+                    throw RuntimeException("Developer Triggered Crash (from DevTools settings)")
+                }
+            )
+
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/SettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
@@ -32,12 +33,14 @@ import androidx.navigation.NavController
 import com.metrolist.music.BuildConfig
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.R
+import com.metrolist.music.constants.DeveloperModeKey
 import com.metrolist.music.ui.component.IconButton
 import com.metrolist.music.ui.component.Material3SettingsGroup
 import com.metrolist.music.ui.component.Material3SettingsItem
 import com.metrolist.music.ui.component.ReleaseNotesCard
 import com.metrolist.music.ui.utils.backToMain
 import com.metrolist.music.utils.Updater
+import com.metrolist.music.utils.rememberPreference
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -49,6 +52,7 @@ fun SettingsScreen(
     val uriHandler = LocalUriHandler.current
     val context = LocalContext.current
     val isAndroid12OrLater = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+    val devMode by rememberPreference(DeveloperModeKey, defaultValue = false)
 
     Column(
         Modifier
@@ -205,6 +209,15 @@ fun SettingsScreen(
                         onClick = { navController.navigate("settings/about") }
                     )
                 )
+                if (devMode) {
+                    add(
+                        Material3SettingsItem(
+                            icon = painterResource(R.drawable.bug_report),
+                            title = { Text(stringResource(R.string.dev_tools)) },
+                            onClick = { navController.navigate("settings/devtools") }
+                        )
+                    )
+                }
                 if (latestVersionName != BuildConfig.VERSION_NAME) {
                     val releaseInfo = Updater.getCachedLatestRelease()
                     val downloadUrl = releaseInfo?.let { Updater.getDownloadUrlForCurrentVariant(it) }

--- a/app/src/main/kotlin/com/metrolist/music/utils/DiscordRPC.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/DiscordRPC.kt
@@ -10,6 +10,7 @@ import com.metrolist.music.R
 import com.metrolist.music.db.entities.Song
 import com.my.kizzy.rpc.KizzyRPC
 import com.my.kizzy.rpc.RpcImage
+import timber.log.Timber
 
 class DiscordRPC(
     val context: Context,
@@ -22,6 +23,12 @@ class DiscordRPC(
     userAgent = SuperProperties.userAgent,
     superPropertiesBase64 = SuperProperties.superPropertiesBase64
 ) {
+    init {
+        Timber.d("DiscordRPC initialized")
+    }
+
+    private var lastLoggedSongId: String? = null
+
     suspend fun updateSong(
         song: Song,
         currentPlaybackTimeMillis: Long,
@@ -35,19 +42,25 @@ class DiscordRPC(
         activityType: String = "listening",
         activityName: String = "",
     ) = runCatching {
+        val validPlaybackSpeed = if (playbackSpeed <= 0f) 1.0f else playbackSpeed
+        if (song.song.id != lastLoggedSongId) {
+            lastLoggedSongId = song.song.id
+            Timber.d("updateSong: title=\"%s\", artist=\"%s\", activityType=%s",
+                song.song.title, song.artists.joinToString { it.name }, activityType)
+        }
         val currentTime = System.currentTimeMillis()
 
-        val adjustedPlaybackTime = (currentPlaybackTimeMillis / playbackSpeed).toLong()
+        val adjustedPlaybackTime = (currentPlaybackTimeMillis / validPlaybackSpeed).toLong()
         val calculatedStartTime = currentTime - adjustedPlaybackTime
 
-        val songTitleWithRate = if (playbackSpeed != 1.0f) {
-            "${song.song.title} [${String.format("%.2fx", playbackSpeed)}]"
+        val songTitleWithRate = if (validPlaybackSpeed != 1.0f) {
+            "${song.song.title} [${String.format(java.util.Locale.US, "%.2fx", validPlaybackSpeed)}]"
         } else {
             song.song.title
         }
 
-        val remainingDuration = song.song.duration * 1000L - currentPlaybackTimeMillis
-        val adjustedRemainingDuration = (remainingDuration / playbackSpeed).toLong()
+        val remainingDuration = (song.song.duration * 1000L - currentPlaybackTimeMillis).coerceAtLeast(0L)
+        val adjustedRemainingDuration = (remainingDuration / validPlaybackSpeed).toLong()
 
         val buttonsList = mutableListOf<Pair<String, String>>()
         if (button1Visible) {
@@ -94,14 +107,26 @@ class DiscordRPC(
             applicationId = APPLICATION_ID,
             status = status
         )
+        Timber.d("updateSong: activity set successfully for \"%s\"", song.song.title)
     }
 
     override suspend fun close() {
+        Timber.d("DiscordRPC closing connection")
+        closeRPC()
         super.close()
     }
 
     companion object {
         private const val APPLICATION_ID = "1411019391843172514"
+
+        /**
+         * Masks a Discord token for safe logging. Shows only the first 4 and
+         * last 2 characters — enough to identify the token without leaking it.
+         */
+        fun maskToken(token: String): String {
+            if (token.length <= 6) return "****"
+            return "${token.take(4)}...${token.takeLast(2)}"
+        }
 
         /**
          * Resolves template variables in text.

--- a/app/src/main/kotlin/com/metrolist/music/utils/ScrobbleManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/ScrobbleManager.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import kotlin.math.min
 
 class ScrobbleManager(
@@ -19,6 +20,9 @@ class ScrobbleManager(
     var scrobbleDelayPercent: Float = 0.5f,
     var scrobbleDelaySeconds: Int = 50
 ) {
+    private companion object {
+        const val TAG = "LastFM"
+    }
     private var scrobbleJob: Job? = null
     private var scrobbleRemainingMillis: Long = 0L
     private var scrobbleTimerStartedAt: Long = 0L
@@ -32,12 +36,14 @@ class ScrobbleManager(
         scrobbleTimerStartedAt = 0L
         songStartedAt = 0L
         songStarted = false
+        Timber.tag(TAG).d("ScrobbleManager destroyed")
     }
 
     fun onSongStart(metadata: MediaMetadata?, duration: Long? = null) {
         if (metadata == null) return
         songStartedAt = System.currentTimeMillis() / 1000
         songStarted = true
+        Timber.tag(TAG).d("onSongStart: ${metadata.title}")
         startScrobbleTimer(metadata, duration)
         if (useNowPlaying) {
             updateNowPlaying(metadata)
@@ -45,14 +51,17 @@ class ScrobbleManager(
     }
 
     fun onSongResume(metadata: MediaMetadata) {
+        Timber.tag(TAG).d("onSongResume: ${metadata.title}")
         resumeScrobbleTimer(metadata)
     }
 
     fun onSongPause() {
+        Timber.tag(TAG).d("onSongPause")
         pauseScrobbleTimer()
     }
 
     fun onSongStop() {
+        Timber.tag(TAG).d("onSongStop")
         stopScrobbleTimer()
         songStarted = false
     }
@@ -61,7 +70,10 @@ class ScrobbleManager(
         scrobbleJob?.cancel()
         val duration = duration?.toInt()?.div(1000) ?: metadata.duration
 
-        if (duration <= minSongDuration) return
+        if (duration <= minSongDuration) {
+            Timber.tag(TAG).d("Song too short to scrobble (${duration}s)")
+            return
+        }
 
         val threshold = duration * 1000L * scrobbleDelayPercent
         scrobbleRemainingMillis = min(threshold.toLong(), scrobbleDelaySeconds * 1000L)
@@ -71,6 +83,7 @@ class ScrobbleManager(
             return
         }
         scrobbleTimerStartedAt = System.currentTimeMillis()
+        Timber.tag(TAG).d("Starting scrobble timer for ${scrobbleRemainingMillis}ms")
         scrobbleJob = scope.launch {
             delay(scrobbleRemainingMillis)
             scrobbleSong(metadata)
@@ -85,7 +98,7 @@ class ScrobbleManager(
             scrobbleRemainingMillis -= elapsed
             if (scrobbleRemainingMillis < 0) scrobbleRemainingMillis = 0
             scrobbleTimerStartedAt = 0L
-        } else {
+            Timber.tag(TAG).d("Scrobble timer paused. ${scrobbleRemainingMillis}ms remaining")
         }
     }
 
@@ -93,6 +106,7 @@ class ScrobbleManager(
         if (scrobbleRemainingMillis <= 0) return
         scrobbleJob?.cancel()
         scrobbleTimerStartedAt = System.currentTimeMillis()
+        Timber.tag(TAG).d("Resuming scrobble timer for ${scrobbleRemainingMillis}ms")
         scrobbleJob = scope.launch {
             delay(scrobbleRemainingMillis)
             scrobbleSong(metadata)
@@ -104,9 +118,11 @@ class ScrobbleManager(
         scrobbleJob?.cancel()
         scrobbleJob = null
         scrobbleRemainingMillis = 0
+        Timber.tag(TAG).d("Scrobble timer stopped")
     }
 
     private fun scrobbleSong(metadata: MediaMetadata) {
+        Timber.tag(TAG).d("Scrobbling: ${metadata.title}")
         scope.launch {
             LastFM.scrobble(
                 artist = metadata.artists.joinToString { it.name },
@@ -119,6 +135,7 @@ class ScrobbleManager(
     }
 
     private fun updateNowPlaying(metadata: MediaMetadata) {
+        Timber.tag(TAG).d("Updating Now Playing: ${metadata.title}")
         scope.launch {
             LastFM.updateNowPlaying(
                 artist = metadata.artists.joinToString { it.name },

--- a/app/src/main/kotlin/com/metrolist/music/utils/Utils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/Utils.kt
@@ -7,10 +7,11 @@ package com.metrolist.music.utils
 
 import android.content.Context
 import android.content.res.Configuration
+import timber.log.Timber
 import java.util.Locale
 
 fun reportException(throwable: Throwable) {
-    throwable.printStackTrace()
+    Timber.e(throwable, "Caught exception in reportException")
 }
 
 @Suppress("DEPRECATION")

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -700,6 +700,7 @@
     <string name="ai_deepl_formality_less">Less Formal</string>
     
     <!-- Crash Handler -->
+    <string name="export_failed">Export failed: %1$s</string>
     <string name="crash_title">App Crashed</string>
     <string name="crash_description">An unexpected error occurred. Please share the crash report to help us fix the issue.</string>
     <string name="crash_share_logs">Share Logs</string>
@@ -913,4 +914,135 @@
     <string name="delete_uploaded_songs_confirm">Are you sure you want to delete %1$d uploaded songs? This cannot be undone.</string>
     <string name="deleted_n_songs">Deleted %1$d songs</string>
     <string name="deleting">Deleting…</string>
+    <string name="select_log">Select Log</string>
+    <!-- DevTools -->
+    <string name="dev_mode_already_enabled">Developer mode is already enabled</string>
+    <plurals name="dev_mode_taps_remaining">
+        <item quantity="one">%d tap to enable developer mode</item>
+        <item quantity="other">%d taps to enable developer mode</item>
+    </plurals>
+    <string name="dev_mode_enabled">Developer mode enabled!</string>
+    <string name="dev_mode_required">Developer mode is required to access this screen</string>
+    <string name="dev_tools">Developer Tools</string>
+    <string name="enable_dev_tools">Enable Developer Tools</string>
+    <string name="enable_dev_tools_desc">Provides floating overlay for logs and state inspection</string>
+    <string name="dev_actions">Developer Actions</string>
+    <string name="dev_actions_subtitle">Active utility tools and exports</string>
+    <string name="export_logs">Export Logs</string>
+    <string name="export_logs_desc">Compiles the in-memory log buffer into a text file and opens the share sheet.</string>
+    <string name="export_now">Export Now</string>
+    <string name="export_devtools_logs">Export DevTools Logs</string>
+    <string name="clear_cache">Clear Cache</string>
+    <string name="clear_cache_desc">Recursively deletes the application cache directory.</string>
+    <string name="cleared_cache_mb">Cleared %d MB from cache</string>
+    <string name="failed_clear_cache">Failed to clear cache: %s</string>
+    <string name="test_crash_handler">Test Crash Handler</string>
+    <string name="test_crash_handler_desc">Throws a fatal RuntimeException to verify the global crash handler and crash activity.</string>
+    <string name="force_crash">Force Crash</string>
+    <string name="environment">Environment</string>
+    <string name="environment_subtitle">Device hardware and app build metrics</string>
+    <string name="app_info">App Info</string>
+    <string name="version_code">Version Code</string>
+    <string name="build_type">Build Type</string>
+    <string name="architecture">Architecture</string>
+    <string name="device_info">Device Info</string>
+    <string name="device_model">Model</string>
+    <string name="android_os">Android OS</string>
+    <string name="resolution">Resolution</string>
+    <string name="density">Density</string>
+    <string name="memory_metrics">Memory Metrics</string>
+    <string name="device_ram">Device RAM</string>
+    <string name="app_heap_limit">App Heap Limit</string>
+    <string name="database">Database</string>
+    <string name="database_subtitle">Local Room database statistics</string>
+    <string name="connection">Connection</string>
+    <string name="database_name">Database Name</string>
+    <string name="status">Status</string>
+    <string name="library_stats">Library Stats</string>
+    <string name="logs">Logs</string>
+    <string name="logs_subtitle">Real-time application logs</string>
+    <string name="search_logs">Search logs...</string>
+    <string name="clear_search">Clear search</string>
+    <string name="selected_count">%d Selected</string>
+    <string name="copy_selected">Copy Selected</string>
+    <string name="clear_selection">Clear Selection</string>
+    <string name="all_levels">All Levels</string>
+    <string name="log_verbose">Verbose</string>
+    <string name="log_debug">Debug</string>
+    <string name="log_info">Info</string>
+    <string name="log_warn">Warn</string>
+    <string name="log_error">Error</string>
+    <string name="all_tags">All Tags</string>
+    <string name="toggle_filters">Toggle Filters</string>
+    <string name="clear_logs">Clear Logs</string>
+
+    <string name="dev_playback">Playback</string>
+    <string name="dev_playback_subtitle">ExoPlayer and MediaSession state</string>
+    <string name="dev_player_status">Status</string>
+    <string name="dev_player_service">Service</string>
+    <string name="dev_player_not_initialized">PlayerConnection not initialized</string>
+    <string name="dev_engine_state">Engine State</string>
+    <string name="dev_service_ready">Service Ready</string>
+    <string name="dev_playback_state">Playback State</string>
+    <string name="dev_is_playing">Is Playing</string>
+    <string name="dev_active_error">Active Error</string>
+    <string name="dev_none">None</string>
+    <string name="dev_current_media">Current Media</string>
+    <string name="dev_media_id">Media ID</string>
+    <string name="dev_title">Title</string>
+    <string name="dev_queue_size">Queue Size</string>
+    <string name="dev_timeline">Timeline</string>
+    <string name="dev_timeline_format">%1$d ms / %2$d ms</string>
+    <string name="dev_tab_logs">Logs</string>
+    <string name="dev_tab_player">Player</string>
+    <string name="dev_tab_env">Env</string>
+    <string name="dev_tab_db">DB</string>
+    <string name="dev_tab_tools">Tools</string>
+    <string name="dev_filter_player">Player</string>
+    <string name="dev_filter_ui">UI</string>
+    <string name="dev_filter_db">DB</string>
+    <string name="dev_filter_integration">Integration</string>
+    <string name="dev_ram_format">%1$s GB (Total)\n%2$s GB (Free)</string>
+    <string name="dev_mb_format">%1$s MB</string>
+    <string name="dev_dpi_format">%1$d dpi</string>
+    <string name="dev_db_name">internal.db</string>
+    <string name="dev_db_connected">Connected</string>
+    <string name="dev_db_disconnected">Disconnected</string>
+    <string name="dev_build_type_debug">Debug</string>
+    <string name="dev_build_type_release">Release</string>
+
+    <string name="dev_background_processes">Background Processes</string>
+    <string name="dev_crossfade_enabled">Crossfade</string>
+    <string name="dev_loudness_enhancer">Loudness Enhancer</string>
+    <string name="dev_discord_rpc">Discord RPC</string>
+    <string name="dev_scrobbling">Scrobbling</string>
+    <string name="dev_sleep_timer_active">Sleep Timer</string>
+
+    <string name="dev_clear_image_cache">Clear Image Cache</string>
+    <string name="dev_clear_image_cache_desc">Clears the Coil memory and disk caches.</string>
+    <string name="dev_cleared_image_cache">Cleared Image Cache</string>
+    <string name="dev_listen_together">Listen Together</string>
+    <string name="dev_listen_together_status">Status</string>
+    <string name="dev_listen_together_room">Room</string>
+    <string name="dev_listen_together_role">Role</string>
+    <string name="dev_listen_together_sync">Drift</string>
+    <string name="dev_listen_together_ws">WebSocket</string>
+    <string name="dev_queue_viewer">Active Queue</string>
+    <string name="dev_queue_viewer_subtitle">Next items</string>
+    <string name="dev_unknown">Unknown</string>
+    <string name="dev_empty">Empty</string>
+    <string name="dev_export_header">--- METROLIST DEVTOOLS EXPORT ---
+App Version: %1$s (%2$s)
+Build Type: %3$s
+Architecture: %4$s
+Device: %5$s %6$s
+OS: Android %7$s (API %8$s)
+Screen: %9$s, %10$s dpi
+Memory: %11$s GB free / %12$s GB total (Max Heap: %13$s MB)
+---------------------------------
+</string>
+    <string name="dev_export_filename">metrolist_logs_%1$s.txt</string>
+    <string name="dev_debug">Debug</string>
+    <string name="dev_release">Release</string>
+
 </resources>

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -5,4 +5,8 @@
     <drawable name="media3_notification_pause">@drawable/pause</drawable>
     <drawable name="media3_notification_seek_to_previous">@drawable/skip_previous</drawable>
     <drawable name="media3_notification_seek_to_next">@drawable/skip_next</drawable>
+
+    <!-- DevTools dimensions -->
+    <dimen name="devtools_fab_bottom_padding">120dp</dimen>
+    <dimen name="devtools_drag_bounds_padding">150dp</dimen>
 </resources>

--- a/development_guide.md
+++ b/development_guide.md
@@ -20,7 +20,7 @@ cd app
 bash generate_proto.sh
 cd ..
 [ ! -f "app/persistent-debug.keystore" ] && keytool -genkeypair -v -keystore app/persistent-debug.keystore -storepass android -keypass android -alias androiddebugkey -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Android Debug,O=Android,C=US" || echo "Keystore already exists."
-./gradlew :app:assembleuniversalFossDebug
+./gradlew :app:assembleFossDebug
 ls app/build/outputs/apk/universalFoss/debug/app-universal-foss-debug.apk
 ```
 

--- a/development_guide.md
+++ b/development_guide.md
@@ -21,7 +21,7 @@ bash generate_proto.sh
 cd ..
 [ ! -f "app/persistent-debug.keystore" ] && keytool -genkeypair -v -keystore app/persistent-debug.keystore -storepass android -keypass android -alias androiddebugkey -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Android Debug,O=Android,C=US" || echo "Keystore already exists."
 ./gradlew :app:assembleFossDebug
-ls app/build/outputs/apk/universalFoss/debug/app-universal-foss-debug.apk
+ls app/build/outputs/apk/foss/debug/app-foss-debug.apk
 ```
 
 ### GitHub Secrets Configuration


### PR DESCRIPTION
## Problem
<!-- Describe the issue or limitation this PR addresses -->
Metrolist lacked developer tools for debugging runtime issues. When problems occurred (e.g., playback failures, sync issues), users and developers had no way to inspect the app's internal state, view logs, or access database information for troubleshooting.

## Cause
<!-- Explain the root cause of the problem -->
The app didn't have any built-in debugging utilities. Logs were only visible in Logcat (requiring ADB), and there was no way to inspect playback state, database contents, or trigger diagnostic actions without external tools.

## Solution
<!-- List the changes made to fix the issue -->
- Added a floating overlay accessible via a FAB button (enabled via Settings → Developer mode)
- Integrated Timber logging with a custom `DevToolsTimberTree` to capture logs in-memory
- Created a thread-safe circular log buffer with configurable max size
- Implemented four panels in the overlay:
  - **Logs**: Searchable/filterable log viewer with level and tag filters
  - **Playback**: ExoPlayer state, queue viewer, background processes (Discord RPC, scrobbling, crossfade, sleep timer)
  - **Database**: View song/album/artist/playlist counts
  - **Tools**: Export logs to file, clear cache, clear image cache
- Exposed necessary fields in `MusicService` (crossfade, Discord RPC, scrobbling, loudness enhancer) as `internal`
- Added 60+ localized strings for all UI elements

## Testing
<!-- Describe how the changes were tested -->
- Built successfully with `./gradlew :app:assembleuniversalFossDebug`
- Verified FAB appears only when developer mode is enabled
- Tested log filtering, log export, cache clearing
- Verified overlay positioning and drag functionality

## Related Issues
<!-- List any related issues or PRs -->
- Closes `None`
- Related to `None`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Developer Tools: hidden tap-to-enable Easter egg in About → Settings, new DevTools settings screen, and Settings entry to enable DevTools.
  * DevTools overlay with tabs for Logs, Player, DB, and Tools; live log viewer with filters, search, selection, copy/export; DB and player inspection panels; actions to export diagnostics, clear app cache, and clear image cache; test-crash action.

* **Chores**
  * Updated build/docs guidance; added numerous DevTools strings and UI dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->